### PR TITLE
feat: shared AppState and error model across core/server/rpc (issue #2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
 name = "alloy-rpc"
 version = "0.1.0"
 dependencies = [
+ "alloy-core",
  "prost",
  "serde",
 ]

--- a/crates/alloy-core/src/lib.rs
+++ b/crates/alloy-core/src/lib.rs
@@ -1,12 +1,118 @@
+use std::sync::Arc;
+
 use thiserror::Error;
 
-#[derive(Debug, Clone, Default)]
-pub struct AppState {
+pub type AlloyResult<T> = Result<T, AlloyError>;
+
+#[derive(Debug, Clone)]
+pub struct AppConfig {
     pub service_name: String,
+    pub environment: String,
+}
+
+impl AppConfig {
+    pub fn local(service_name: impl Into<String>) -> Self {
+        Self {
+            service_name: service_name.into(),
+            environment: "local".to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Error)]
 pub enum AlloyError {
+    #[error("validation error: {0}")]
+    Validation(String),
     #[error("internal error: {0}")]
     Internal(String),
+}
+
+pub trait GreetingEngine: Send + Sync {
+    fn greet(&self, name: &str) -> AlloyResult<String>;
+}
+
+pub trait MetricsSink: Send + Sync {
+    fn incr_counter(&self, name: &str);
+}
+
+#[derive(Debug, Default)]
+pub struct NoopMetrics;
+
+impl MetricsSink for NoopMetrics {
+    fn incr_counter(&self, _name: &str) {}
+}
+
+#[derive(Debug, Clone)]
+pub struct StaticGreetingEngine {
+    prefix: String,
+}
+
+impl StaticGreetingEngine {
+    pub fn new(prefix: impl Into<String>) -> Self {
+        Self {
+            prefix: prefix.into(),
+        }
+    }
+}
+
+impl GreetingEngine for StaticGreetingEngine {
+    fn greet(&self, name: &str) -> AlloyResult<String> {
+        if name.trim().is_empty() {
+            return Err(AlloyError::Validation("name must not be empty".to_string()));
+        }
+        Ok(format!("{}, {}!", self.prefix, name))
+    }
+}
+
+#[derive(Clone)]
+pub struct AppState {
+    pub config: AppConfig,
+    pub greeter: Arc<dyn GreetingEngine>,
+    pub metrics: Arc<dyn MetricsSink>,
+}
+
+impl AppState {
+    pub fn new(
+        config: AppConfig,
+        greeter: Arc<dyn GreetingEngine>,
+        metrics: Arc<dyn MetricsSink>,
+    ) -> Self {
+        Self {
+            config,
+            greeter,
+            metrics,
+        }
+    }
+
+    pub fn local(service_name: impl Into<String>) -> Self {
+        Self {
+            config: AppConfig::local(service_name),
+            greeter: Arc::new(StaticGreetingEngine::new("Hello")),
+            metrics: Arc::new(NoopMetrics),
+        }
+    }
+
+    pub fn greet(&self, name: &str) -> AlloyResult<String> {
+        self.metrics.incr_counter("greet.requests");
+        self.greeter.greet(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn greet_rejects_empty_name() {
+        let state = AppState::local("alloy-test");
+        let result = state.greet("  ");
+        assert!(matches!(result, Err(AlloyError::Validation(_))));
+    }
+
+    #[test]
+    fn greet_returns_message() {
+        let state = AppState::local("alloy-test");
+        let result = state.greet("Rust");
+        assert_eq!(result.expect("must greet"), "Hello, Rust!");
+    }
 }

--- a/crates/alloy-rpc/Cargo.toml
+++ b/crates/alloy-rpc/Cargo.toml
@@ -5,5 +5,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+alloy-core = { path = "../alloy-core" }
 prost.workspace = true
 serde.workspace = true

--- a/crates/alloy-rpc/src/lib.rs
+++ b/crates/alloy-rpc/src/lib.rs
@@ -1,3 +1,4 @@
+use alloy_core::{AlloyResult, AppState};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -8,4 +9,9 @@ pub struct HelloRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HelloResponse {
     pub message: String,
+}
+
+pub fn build_hello_response(state: &AppState, request: HelloRequest) -> AlloyResult<HelloResponse> {
+    let message = state.greet(&request.name)?;
+    Ok(HelloResponse { message })
 }

--- a/crates/alloy-server/src/lib.rs
+++ b/crates/alloy-server/src/lib.rs
@@ -1,11 +1,45 @@
 use std::sync::Arc;
 
-use alloy_core::AppState;
-use axum::{routing::get, Router};
+use alloy_core::{AlloyError, AppState};
+use alloy_rpc::{build_hello_response, HelloRequest};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    routing::get,
+    Router,
+};
 
 pub fn build_router(state: Arc<AppState>) -> Router {
     Router::new()
-        .route("/", get(|| async { "Alloy server" }))
-        .route("/health", get(|| async { "OK" }))
+        .route("/", get(root))
+        .route("/health", get(health))
+        .route("/hello/:name", get(hello))
         .with_state(state)
+}
+
+async fn root(State(state): State<Arc<AppState>>) -> String {
+    format!(
+        "{} ({})",
+        state.config.service_name, state.config.environment
+    )
+}
+
+async fn health(State(state): State<Arc<AppState>>) -> &'static str {
+    state.metrics.incr_counter("http.health.requests");
+    "OK"
+}
+
+async fn hello(
+    Path(name): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Result<String, (StatusCode, String)> {
+    let response = build_hello_response(&state, HelloRequest { name }).map_err(map_error)?;
+    Ok(response.message)
+}
+
+fn map_error(err: AlloyError) -> (StatusCode, String) {
+    match err {
+        AlloyError::Validation(message) => (StatusCode::BAD_REQUEST, message),
+        AlloyError::Internal(message) => (StatusCode::INTERNAL_SERVER_ERROR, message),
+    }
 }

--- a/crates/alloy-server/src/main.rs
+++ b/crates/alloy-server/src/main.rs
@@ -12,9 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    let state = Arc::new(AppState {
-        service_name: "alloy-server".to_string(),
-    });
+    let state = Arc::new(AppState::local("alloy-server"));
 
     let app = build_router(state);
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));

--- a/examples/simple-server/src/main.rs
+++ b/examples/simple-server/src/main.rs
@@ -6,9 +6,7 @@ use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let state = Arc::new(AppState {
-        service_name: "simple-server".to_string(),
-    });
+    let state = Arc::new(AppState::local("simple-server"));
     let app = build_router(state);
     let listener = TcpListener::bind(("127.0.0.1", 4000)).await?;
     axum::serve(listener, app).await?;


### PR DESCRIPTION
## Summary
- expand `alloy-core` with shared domain primitives:
  - `AppConfig`
  - `AppState`
  - `AlloyError` / `AlloyResult`
  - reusable interfaces: `GreetingEngine`, `MetricsSink`
- add default implementations (`StaticGreetingEngine`, `NoopMetrics`)
- add `AppState::local(...)` bootstrap helper and `AppState::greet(...)` shared behavior
- connect `alloy-rpc` to core via `build_hello_response(...)`
- update `alloy-server` and example app to consume new shared state model
- add unit tests in `alloy-core`

## Why
Implements issue #2 to establish a single shared state and error model that both REST and gRPC layers can consume.

## Validation
- `cargo test --workspace -q`

Closes #2
