### PR TITLE
feat: bootstrap server with env addr and health test (issue #4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "alloy-rpc",
  "axum",
  "tokio",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/crates/alloy-server/Cargo.toml
+++ b/crates/alloy-server/Cargo.toml
@@ -12,3 +12,6 @@ tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tower-http.workspace = true
+
+[dev-dependencies]
+tower.workspace = true

--- a/crates/alloy-server/src/lib.rs
+++ b/crates/alloy-server/src/lib.rs
@@ -43,3 +43,21 @@ fn map_error(err: AlloyError) -> (StatusCode, String) {
         AlloyError::Internal(message) => (StatusCode::INTERNAL_SERVER_ERROR, message),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{Request, StatusCode};
+    use tower::util::ServiceExt;
+
+    #[tokio::test]
+    async fn health_returns_ok() {
+        let app = build_router(Arc::new(AppState::local("test-server")));
+        let response = app
+            .oneshot(Request::builder().uri("/health").body(axum::body::Body::empty()).unwrap())
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/crates/alloy-server/src/main.rs
+++ b/crates/alloy-server/src/main.rs
@@ -1,8 +1,9 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{env, net::SocketAddr, sync::Arc};
 
 use alloy_core::AppState;
 use alloy_server::build_router;
 use tokio::net::TcpListener;
+use tower_http::trace::TraceLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -14,11 +15,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let state = Arc::new(AppState::local("alloy-server"));
 
-    let app = build_router(state);
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    let app = build_router(state).layer(TraceLayer::new_for_http());
+    let addr = load_addr_from_env()?;
     let listener = TcpListener::bind(addr).await?;
 
     tracing::info!(%addr, "alloy-server listening");
     axum::serve(listener, app).await?;
     Ok(())
+}
+
+fn load_addr_from_env() -> Result<SocketAddr, Box<dyn std::error::Error>> {
+    match env::var("ALLOY_SERVER_ADDR") {
+        Ok(raw) => Ok(raw.parse()?),
+        Err(env::VarError::NotPresent) => Ok(SocketAddr::from(([127, 0, 0, 1], 3000))),
+        Err(err) => Err(Box::new(err)),
+    }
 }


### PR DESCRIPTION
## Summary
- finalize server bootstrap path for `alloy-server`
- add env-based address loading via `ALLOY_SERVER_ADDR`
- apply `TraceLayer::new_for_http()` so request logs are emitted
- keep base Axum router with `/` and `/health`
- add unit test for `/health` status code in `alloy-server`

## Why
Issue #4 requires a stable startup path with health endpoint and logging before multiplexing work.

## Validation
- `cargo test -p alloy-server -q`
- `cargo check --workspace`

Closes #4
