### PR TITLE
feat: shared middleware + observability stack for REST and gRPC (issue #6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,6 +1731,7 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1751,6 +1752,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1886,6 +1888,17 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+dependencies = [
+ "getrandom 0.3.4",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,6 @@ tonic = { version = "0.12", features = ["transport"] }
 tonic-build = "0.12"
 prost = "0.13"
 protoc-bin-vendored = "3"
-tower = "0.5"
-tower-http = { version = "0.5", features = ["trace"] }
+tower = { version = "0.5", features = ["limit", "timeout", "util"] }
+tower-http = { version = "0.5", features = ["trace", "cors", "request-id"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }

--- a/crates/alloy-server/Cargo.toml
+++ b/crates/alloy-server/Cargo.toml
@@ -10,10 +10,10 @@ alloy-rpc = { path = "../alloy-rpc" }
 axum.workspace = true
 tokio.workspace = true
 tonic.workspace = true
+tower.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tower-http.workspace = true
 
 [dev-dependencies]
 reqwest.workspace = true
-tower.workspace = true

--- a/crates/alloy-server/src/lib.rs
+++ b/crates/alloy-server/src/lib.rs
@@ -11,6 +11,7 @@ use axum::{
 use tonic::service::Routes;
 
 pub mod grpc;
+pub mod middleware;
 
 pub fn build_router(state: Arc<AppState>) -> Router {
     Router::new()

--- a/crates/alloy-server/src/middleware.rs
+++ b/crates/alloy-server/src/middleware.rs
@@ -1,0 +1,86 @@
+use std::{env, str::FromStr, time::Duration};
+
+use axum::{
+    error_handling::HandleErrorLayer,
+    http::{HeaderName, StatusCode},
+    BoxError, Router,
+};
+use tower::{limit::ConcurrencyLimitLayer, timeout::TimeoutLayer, ServiceBuilder};
+use tower_http::{
+    cors::{Any, CorsLayer},
+    request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
+    trace::TraceLayer,
+};
+
+const REQUEST_ID_HEADER: &str = "x-request-id";
+
+#[derive(Debug, Clone)]
+pub struct MiddlewareConfig {
+    pub timeout_seconds: u64,
+    pub max_in_flight_requests: usize,
+}
+
+impl Default for MiddlewareConfig {
+    fn default() -> Self {
+        Self {
+            timeout_seconds: 15,
+            max_in_flight_requests: 1024,
+        }
+    }
+}
+
+impl MiddlewareConfig {
+    pub fn from_env() -> Self {
+        Self {
+            timeout_seconds: read_env("ALLOY_TIMEOUT_SECONDS").unwrap_or(15),
+            max_in_flight_requests: read_env("ALLOY_MAX_IN_FLIGHT_REQUESTS").unwrap_or(1024),
+        }
+    }
+}
+
+pub fn apply_shared_middleware(app: Router, config: &MiddlewareConfig) -> Router {
+    app.layer(
+        ServiceBuilder::new()
+            .layer(HandleErrorLayer::new(handle_middleware_error))
+            .layer(TraceLayer::new_for_http())
+            .layer(CorsLayer::new().allow_origin(Any))
+            .layer(PropagateRequestIdLayer::new(header_name()))
+            .layer(SetRequestIdLayer::new(header_name(), MakeRequestUuid))
+            .layer(TimeoutLayer::new(Duration::from_secs(config.timeout_seconds)))
+            .layer(ConcurrencyLimitLayer::new(config.max_in_flight_requests)),
+    )
+}
+
+async fn handle_middleware_error(error: BoxError) -> (StatusCode, String) {
+    if error.is::<tower::timeout::error::Elapsed>() {
+        return (StatusCode::REQUEST_TIMEOUT, "request timed out".to_string());
+    }
+
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        format!("middleware error: {error}"),
+    )
+}
+
+fn header_name() -> HeaderName {
+    HeaderName::from_static(REQUEST_ID_HEADER)
+}
+
+fn read_env<T>(name: &str) -> Option<T>
+where
+    T: FromStr,
+{
+    env::var(name).ok().and_then(|raw| raw.parse::<T>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_reasonable() {
+        let config = MiddlewareConfig::default();
+        assert_eq!(config.timeout_seconds, 15);
+        assert_eq!(config.max_in_flight_requests, 1024);
+    }
+}

--- a/crates/alloy-server/tests/multiplexing.rs
+++ b/crates/alloy-server/tests/multiplexing.rs
@@ -2,14 +2,17 @@ use std::sync::Arc;
 
 use alloy_core::AppState;
 use alloy_rpc::{GreeterClient, HelloRequest};
-use alloy_server::build_multiplexed_router;
+use alloy_server::{build_multiplexed_router, middleware};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 
 #[tokio::test]
 async fn serves_rest_and_grpc_on_single_port() {
     let state = Arc::new(AppState::local("multiplexing-test"));
-    let app = build_multiplexed_router(state);
+    let app = middleware::apply_shared_middleware(
+        build_multiplexed_router(state),
+        &middleware::MiddlewareConfig::default(),
+    );
     let listener = TcpListener::bind(("127.0.0.1", 0))
         .await
         .expect("bind test listener");
@@ -28,13 +31,38 @@ async fn serves_rest_and_grpc_on_single_port() {
     let base_url = format!("http://{addr}");
 
     // Basic retry to avoid flaky startup race in CI.
-    let health_status = loop {
-        match reqwest::get(format!("{base_url}/health")).await {
+    let rest_client = reqwest::Client::builder()
+        .build()
+        .expect("build reqwest client");
+
+    let health_response = loop {
+        match rest_client
+            .get(format!("{base_url}/health"))
+            .header("x-request-id", "test-request-id")
+            .send()
+            .await
+        {
             Ok(resp) => break resp.status(),
             Err(_) => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
         }
     };
-    assert_eq!(health_status.as_u16(), 200);
+    assert_eq!(health_response.as_u16(), 200);
+
+    let hello_response = rest_client
+        .get(format!("{base_url}/hello/Rust"))
+        .header("x-request-id", "rest-hello-id")
+        .send()
+        .await
+        .expect("rest hello should succeed");
+    assert_eq!(
+        hello_response
+            .headers()
+            .get("x-request-id")
+            .expect("x-request-id should be propagated")
+            .to_str()
+            .expect("request id must be valid header"),
+        "rest-hello-id"
+    );
 
     let mut grpc_client = GreeterClient::connect(base_url)
         .await

--- a/docs/observability-and-middleware.md
+++ b/docs/observability-and-middleware.md
@@ -1,0 +1,22 @@
+# Shared Middleware And Observability
+
+This project applies one centralized middleware stack for both REST and gRPC traffic.
+
+Source:
+- `crates/alloy-server/src/middleware.rs`
+
+Included layers:
+- `TraceLayer` for structured request tracing
+- `SetRequestIdLayer` to generate `x-request-id` when missing
+- `PropagateRequestIdLayer` to echo request ID in responses
+- `CorsLayer` with permissive origin policy (for REST/browser integration)
+- `TimeoutLayer` for request timeout boundaries
+- `ConcurrencyLimitLayer` for in-flight request control
+
+Environment variables:
+- `ALLOY_TIMEOUT_SECONDS` (default: `15`)
+- `ALLOY_MAX_IN_FLIGHT_REQUESTS` (default: `1024`)
+
+Notes:
+- Middleware is applied in `crates/alloy-server/src/main.rs`.
+- Because the app is multiplexed (REST + gRPC on one listener), these layers are shared by both protocol paths.


### PR DESCRIPTION
## Summary
- add a centralized shared middleware module for REST + gRPC:
  - `TraceLayer`
  - request-id generation/propagation (`x-request-id`)
  - CORS policy
  - timeout + concurrency limit controls
- wire middleware in server bootstrap so both REST and gRPC paths use one stack
- add middleware configuration via env:
  - `ALLOY_TIMEOUT_SECONDS`
  - `ALLOY_MAX_IN_FLIGHT_REQUESTS`
- add middleware error handling for timeout and internal failures

## Validation and coverage
- extend multiplexing integration test to run with middleware stack enabled
- assert request-id propagation on REST responses
- verify gRPC call still succeeds on shared port

## Documentation
- add centralized middleware/observability guide:
  - `docs/observability-and-middleware.md`

## Checks run
- `cargo test -p alloy-server --test multiplexing -q`
- `cargo test -p alloy-server -q`
- `cargo check --workspace`

Closes #6
