### PR TITLE
feat: add fluent AlloyServer builder API (issue #9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "alloy-core",
  "alloy-rpc",
  "axum",
+ "http",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,4 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 serde_json = "1"
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "8", features = ["axum"] }
+http = "1"

--- a/crates/alloy-server/Cargo.toml
+++ b/crates/alloy-server/Cargo.toml
@@ -18,6 +18,7 @@ utoipa.workspace = true
 utoipa-swagger-ui.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+http.workspace = true
 
 [dev-dependencies]
 reqwest.workspace = true

--- a/crates/alloy-server/src/builder.rs
+++ b/crates/alloy-server/src/builder.rs
@@ -1,0 +1,202 @@
+use std::{convert::Infallible, env, net::SocketAddr, sync::Arc};
+
+use alloy_core::AppState;
+use axum::Router;
+use http::{Request, Response};
+use tokio::net::TcpListener;
+use tonic::{body::BoxBody, server::NamedService, service::Routes};
+use tower::Service;
+
+use crate::{build_router, grpc, middleware};
+
+type RouterCustomizer = Box<dyn Fn(Router) -> Router + Send + Sync + 'static>;
+type StartupHook = Box<dyn Fn(SocketAddr) + Send + Sync + 'static>;
+type ShutdownHook = Box<dyn Fn() + Send + Sync + 'static>;
+
+pub struct AlloyServer {
+    state: Arc<AppState>,
+    addr: SocketAddr,
+    rest_router: Option<Router>,
+    grpc_routes: Option<Routes>,
+    middleware_config: middleware::MiddlewareConfig,
+    middleware_customizers: Vec<RouterCustomizer>,
+    startup_hooks: Vec<StartupHook>,
+    shutdown_hooks: Vec<ShutdownHook>,
+}
+
+impl AlloyServer {
+    pub fn new() -> Self {
+        let state = Arc::new(AppState::local("alloy-server"));
+        Self {
+            grpc_routes: Some(Routes::new(grpc::build_grpc_service(state.clone())).prepare()),
+            state,
+            addr: load_addr_from_env().unwrap_or(SocketAddr::from(([127, 0, 0, 1], 3000))),
+            rest_router: None,
+            middleware_config: middleware::MiddlewareConfig::from_env(),
+            middleware_customizers: Vec::new(),
+            startup_hooks: Vec::new(),
+            shutdown_hooks: Vec::new(),
+        }
+    }
+
+    pub fn with_addr(mut self, addr: SocketAddr) -> Self {
+        self.addr = addr;
+        self
+    }
+
+    pub fn with_state(mut self, state: Arc<AppState>) -> Self {
+        self.state = state;
+        self
+    }
+
+    pub fn with_rest_router(mut self, router: Router) -> Self {
+        self.rest_router = Some(router);
+        self
+    }
+
+    pub fn without_grpc(mut self) -> Self {
+        self.grpc_routes = None;
+        self
+    }
+
+    pub fn with_grpc_service<S>(mut self, service: S) -> Self
+    where
+        S: Service<Request<BoxBody>, Response = Response<BoxBody>, Error = Infallible>
+            + NamedService
+            + Clone
+            + Send
+            + 'static,
+        S::Future: Send + 'static,
+    {
+        let routes = match self.grpc_routes.take() {
+            Some(existing) => existing.add_service(service).prepare(),
+            None => Routes::new(service).prepare(),
+        };
+        self.grpc_routes = Some(routes);
+        self
+    }
+
+    pub fn with_grpc_routes(mut self, routes: Routes) -> Self {
+        self.grpc_routes = Some(routes.prepare());
+        self
+    }
+
+    pub fn with_middleware_config(mut self, config: middleware::MiddlewareConfig) -> Self {
+        self.middleware_config = config;
+        self
+    }
+
+    pub fn with_middleware<F>(mut self, f: F) -> Self
+    where
+        F: Fn(Router) -> Router + Send + Sync + 'static,
+    {
+        self.middleware_customizers.push(Box::new(f));
+        self
+    }
+
+    pub fn on_startup<F>(mut self, hook: F) -> Self
+    where
+        F: Fn(SocketAddr) + Send + Sync + 'static,
+    {
+        self.startup_hooks.push(Box::new(hook));
+        self
+    }
+
+    pub fn on_shutdown<F>(mut self, hook: F) -> Self
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.shutdown_hooks.push(Box::new(hook));
+        self
+    }
+
+    pub fn build_app(&self) -> Router {
+        let rest = self
+            .rest_router
+            .clone()
+            .unwrap_or_else(|| build_router(self.state.clone()));
+        let merged = match &self.grpc_routes {
+            Some(routes) => rest.merge(routes.clone().into_axum_router()),
+            None => rest,
+        };
+
+        let app = middleware::apply_shared_middleware(merged, &self.middleware_config);
+        self.middleware_customizers
+            .iter()
+            .fold(app, |acc, customizer| customizer(acc))
+    }
+
+    pub async fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+        let app = self.build_app();
+        let listener = TcpListener::bind(self.addr).await?;
+
+        for hook in &self.startup_hooks {
+            hook(self.addr);
+        }
+        tracing::info!(addr = %self.addr, "alloy-server listening");
+
+        let shutdown_hooks = self.shutdown_hooks;
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = tokio::signal::ctrl_c().await;
+                for hook in &shutdown_hooks {
+                    hook();
+                }
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+impl Default for AlloyServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn load_addr_from_env() -> Result<SocketAddr, Box<dyn std::error::Error>> {
+    match env::var("ALLOY_SERVER_ADDR") {
+        Ok(raw) => Ok(raw.parse()?),
+        Err(env::VarError::NotPresent) => Ok(SocketAddr::from(([127, 0, 0, 1], 3000))),
+        Err(err) => Err(Box::new(err)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::get,
+    };
+    use tower::util::ServiceExt;
+
+    #[tokio::test]
+    async fn builder_creates_working_app() {
+        let app = AlloyServer::new().build_app();
+        let response = app
+            .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+            .await
+            .expect("health request should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn builder_supports_custom_rest_and_middleware_chain() {
+        let custom_router = Router::new().route("/custom", get(|| async { "custom-ok" }));
+        let app = AlloyServer::new()
+            .without_grpc()
+            .with_rest_router(custom_router)
+            .with_middleware(|router| {
+                router.route("/ping", get(|| async { "pong" }))
+            })
+            .build_app();
+
+        let ping_response = app
+            .oneshot(Request::builder().uri("/ping").body(Body::empty()).unwrap())
+            .await
+            .expect("ping request should succeed");
+        assert_eq!(ping_response.status(), StatusCode::OK);
+    }
+}

--- a/crates/alloy-server/src/lib.rs
+++ b/crates/alloy-server/src/lib.rs
@@ -18,8 +18,10 @@ use tonic::service::Routes;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
+pub mod builder;
 pub mod grpc;
 pub mod middleware;
+pub use builder::AlloyServer;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct RootResponse {

--- a/crates/alloy-server/src/main.rs
+++ b/crates/alloy-server/src/main.rs
@@ -1,8 +1,4 @@
-use std::{env, net::SocketAddr, sync::Arc};
-
-use alloy_core::AppState;
-use alloy_server::{build_multiplexed_router, middleware};
-use tokio::net::TcpListener;
+use alloy_server::AlloyServer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -12,22 +8,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    let state = Arc::new(AppState::local("alloy-server"));
-    let middleware_config = middleware::MiddlewareConfig::from_env();
-
-    let app = middleware::apply_shared_middleware(build_multiplexed_router(state), &middleware_config);
-    let addr = load_addr_from_env()?;
-    let listener = TcpListener::bind(addr).await?;
-
-    tracing::info!(%addr, "alloy-server listening");
-    axum::serve(listener, app).await?;
+    AlloyServer::new().run().await?;
     Ok(())
-}
-
-fn load_addr_from_env() -> Result<SocketAddr, Box<dyn std::error::Error>> {
-    match env::var("ALLOY_SERVER_ADDR") {
-        Ok(raw) => Ok(raw.parse()?),
-        Err(env::VarError::NotPresent) => Ok(SocketAddr::from(([127, 0, 0, 1], 3000))),
-        Err(err) => Err(Box::new(err)),
-    }
 }

--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -1,0 +1,35 @@
+# FastAPI-Like Builder API
+
+Alloy exposes a fluent server builder for a compact startup flow.
+
+## Quick Start
+
+```rust
+use std::net::SocketAddr;
+
+use alloy_server::AlloyServer;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    AlloyServer::new()
+        .with_addr(SocketAddr::from(([127, 0, 0, 1], 3000)))
+        .run()
+        .await?;
+    Ok(())
+}
+```
+
+## Common Customization Points
+
+- `with_state(...)`: inject shared app state
+- `with_rest_router(...)`: replace default REST router
+- `with_grpc_service(...)`: add typed gRPC service
+- `without_grpc()`: run REST-only mode
+- `with_middleware_config(...)`: configure shared middleware
+- `with_middleware(...)`: add custom router-level middleware
+- `on_startup(...)` / `on_shutdown(...)`: attach lifecycle hooks
+
+## Notes
+
+- Default `AlloyServer::new()` enables both REST and gRPC on a single listener.
+- Default address uses `ALLOY_SERVER_ADDR` if set, otherwise `127.0.0.1:3000`.

--- a/examples/simple-server/src/main.rs
+++ b/examples/simple-server/src/main.rs
@@ -1,14 +1,12 @@
-use std::sync::Arc;
+use std::net::SocketAddr;
 
-use alloy_core::AppState;
-use alloy_server::build_router;
-use tokio::net::TcpListener;
+use alloy_server::AlloyServer;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let state = Arc::new(AppState::local("simple-server"));
-    let app = build_router(state);
-    let listener = TcpListener::bind(("127.0.0.1", 4000)).await?;
-    axum::serve(listener, app).await?;
+    AlloyServer::new()
+        .with_addr(SocketAddr::from(([127, 0, 0, 1], 4000)))
+        .run()
+        .await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
Introduce a fluent, FastAPI-like server builder API for Alloy.

### New API
- Added `AlloyServer` builder (`crates/alloy-server/src/builder.rs`)
- Chainable methods:
  - `new()` / `default()`
  - `with_addr(...)`
  - `with_state(...)`
  - `with_rest_router(...)`
  - `with_grpc_service(...)`
  - `with_grpc_routes(...)`
  - `without_grpc()`
  - `with_middleware_config(...)`
  - `with_middleware(...)`
  - `on_startup(...)` / `on_shutdown(...)`
  - `build_app()`
  - `run()`

### Integration updates
- Re-export builder as `alloy_server::AlloyServer`
- `alloy-server` binary now boots via `AlloyServer::new().run()`
- `examples/simple-server` updated to builder usage

### Docs
- Added quick guide: `docs/fastapi-like-builder.md`

### Tests
- Added builder-focused tests for fluent setup and middleware extension

## Checks run
- `cargo test -p alloy-server -q`
- `cargo check --workspace`

Closes #9
