### PR TITLE
feat: add e2e tests and CI workflow for REST gRPC docs (issue #10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: Alloy CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop]
+
+jobs:
+  core-build-test:
+    name: Core Build And Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Workspace check
+        run: cargo check --workspace
+
+      - name: Workspace tests
+        run: cargo test --workspace
+
+  rest-grpc-e2e:
+    name: REST gRPC E2E
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run multiplexing integration test
+        run: cargo test -p alloy-server --test multiplexing -- --nocapture
+
+  docs-contract:
+    name: Docs Contract Drift Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Check generated gRPC docs are up-to-date
+        run: ./scripts/check_grpc_contract_docs.sh
+
+      - name: Verify OpenAPI route test
+        run: cargo test -p alloy-server openapi_json_is_available -- --nocapture

--- a/crates/alloy-rpc/tests/contract_codegen.rs
+++ b/crates/alloy-rpc/tests/contract_codegen.rs
@@ -1,0 +1,43 @@
+use alloy_core::AppState;
+use alloy_rpc::{
+    build_hello_response, Greeter, GreeterServer, HelloRequest, HelloResponse,
+};
+use tonic::{Request, Response, Status};
+
+#[derive(Default)]
+struct TestGreeter;
+
+#[tonic::async_trait]
+impl Greeter for TestGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<HelloRequest>,
+    ) -> Result<Response<HelloResponse>, Status> {
+        let req = request.into_inner();
+        Ok(Response::new(HelloResponse {
+            message: format!("hi {}", req.name),
+        }))
+    }
+}
+
+#[test]
+fn generated_types_and_service_are_usable() {
+    let _svc = GreeterServer::new(TestGreeter);
+    let _req = HelloRequest {
+        name: "Rust".to_string(),
+    };
+}
+
+#[test]
+fn build_hello_response_matches_domain_behavior() {
+    let state = AppState::local("rpc-contract-test");
+    let result = build_hello_response(
+        &state,
+        HelloRequest {
+            name: "Rust".to_string(),
+        },
+    )
+    .expect("response should be built");
+
+    assert_eq!(result.message, "Hello, Rust!");
+}

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -1,0 +1,24 @@
+# CI Workflow
+
+This project uses three CI jobs so failures are clearly scoped:
+
+1. `Core Build And Test`
+- `cargo check --workspace`
+- `cargo test --workspace`
+
+2. `REST gRPC E2E`
+- `cargo test -p alloy-server --test multiplexing -- --nocapture`
+
+3. `Docs Contract Drift Check`
+- `./scripts/check_grpc_contract_docs.sh`
+- `cargo test -p alloy-server openapi_json_is_available -- --nocapture`
+
+## Local Equivalent
+
+Run:
+
+```bash
+./scripts/ci_local.sh
+```
+
+This runs the same command set as CI in a single local flow.

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[1/5] cargo check --workspace"
+cargo check --workspace
+
+echo "[2/5] cargo test --workspace"
+cargo test --workspace
+
+echo "[3/5] cargo test -p alloy-server --test multiplexing -- --nocapture"
+cargo test -p alloy-server --test multiplexing -- --nocapture
+
+echo "[4/5] scripts/check_grpc_contract_docs.sh"
+./scripts/check_grpc_contract_docs.sh
+
+echo "[5/5] cargo test -p alloy-server openapi_json_is_available -- --nocapture"
+cargo test -p alloy-server openapi_json_is_available -- --nocapture
+
+echo "Local CI flow completed."


### PR DESCRIPTION
## Summary
Finalize regression protection with end-to-end tests and CI for REST + gRPC + docs paths.

### Test coverage additions
- Extended multiplexing E2E (`crates/alloy-server/tests/multiplexing.rs`) to assert:
  - REST endpoints
  - gRPC method call
  - Swagger UI endpoint (`/docs`)
  - OpenAPI JSON endpoint (`/openapi.json`)
  - gRPC contract bridge endpoint (`/grpc/contracts/openapi.json`)
  - request-id propagation
- Added gRPC contract/codegen compatibility tests:
  - `crates/alloy-rpc/tests/contract_codegen.rs`

### CI pipeline
- Added GitHub Actions workflow: `.github/workflows/ci.yml`
- Job split for clear failure domains:
  - `Core Build And Test`
  - `REST gRPC E2E`
  - `Docs Contract Drift Check`

### Local parity with CI
- Added local CI runner script: `scripts/ci_local.sh`
- Added workflow docs: `docs/ci-workflow.md`

## Validation
Executed locally:
- `./scripts/ci_local.sh`

Closes #10
