### PR TITLE
feat: FastAPI-style DTO validation/error pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,7 @@ dependencies = [
  "tracing-subscriber",
  "utoipa",
  "utoipa-swagger-ui",
+ "validator",
 ]
 
 [[package]]
@@ -274,6 +275,41 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -724,6 +760,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1075,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -1617,7 +1681,10 @@ dependencies = [
  "alloy-server",
  "axum",
  "serde",
+ "serde_json",
  "tokio",
+ "tower 0.5.3",
+ "validator",
 ]
 
 [[package]]
@@ -1657,6 +1724,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2140,6 +2213,36 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validator"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b4a29d8709210980a09379f27ee31549b73292c87ab9899beee1c0d3be6303"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac855a2ce6f843beb229757e6e570a42e837bcb15e5f449dd48d5747d41bf77"
+dependencies = [
+ "darling",
+ "once_cell",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ serde_json = "1"
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "8", features = ["axum"] }
 http = "1"
+validator = { version = "0.19", features = ["derive"] }

--- a/crates/alloy-server/Cargo.toml
+++ b/crates/alloy-server/Cargo.toml
@@ -19,6 +19,7 @@ utoipa-swagger-ui.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 http.workspace = true
+validator.workspace = true
 
 [dev-dependencies]
 reqwest.workspace = true

--- a/crates/alloy-server/src/api.rs
+++ b/crates/alloy-server/src/api.rs
@@ -1,0 +1,118 @@
+use axum::{
+    extract::{FromRequest, FromRequestParts, Query},
+    http::{request::Parts, StatusCode},
+    response::IntoResponse,
+    Json,
+};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::{json, Value};
+use validator::{Validate, ValidationErrors};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiErrorResponse {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<Value>,
+}
+
+impl ApiErrorResponse {
+    pub fn validation(message: impl Into<String>, details: Option<Value>) -> Self {
+        Self {
+            code: "validation_error".to_string(),
+            message: message.into(),
+            details,
+        }
+    }
+
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self {
+            code: "bad_request".to_string(),
+            message: message.into(),
+            details: None,
+        }
+    }
+}
+
+pub type ApiError = (StatusCode, Json<ApiErrorResponse>);
+
+pub fn validation_error(err: ValidationErrors) -> ApiError {
+    let mut fields = serde_json::Map::new();
+    for (field, errors) in err.field_errors() {
+        let messages: Vec<String> = errors
+            .iter()
+            .map(|e| {
+                e.message
+                    .clone()
+                    .map(|m| m.to_string())
+                    .unwrap_or_else(|| e.code.to_string())
+            })
+            .collect();
+        fields.insert(field.to_string(), json!(messages));
+    }
+
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ApiErrorResponse::validation(
+            "request validation failed",
+            Some(Value::Object(fields)),
+        )),
+    )
+}
+
+pub fn bad_request(message: impl Into<String>) -> ApiError {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ApiErrorResponse::bad_request(message)),
+    )
+}
+
+#[derive(Debug, Clone)]
+pub struct ValidatedJson<T>(pub T);
+
+#[axum::async_trait]
+impl<T, S> FromRequest<S> for ValidatedJson<T>
+where
+    T: DeserializeOwned + Validate,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request(
+        req: axum::extract::Request,
+        state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        let Json(value) = Json::<T>::from_request(req, state)
+            .await
+            .map_err(|err| bad_request(format!("invalid json body: {err}")))?;
+
+        value.validate().map_err(validation_error)?;
+        Ok(Self(value))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ValidatedQuery<T>(pub T);
+
+#[axum::async_trait]
+impl<T, S> FromRequestParts<S> for ValidatedQuery<T>
+where
+    T: DeserializeOwned + Validate,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let Query(value) = Query::<T>::from_request_parts(parts, state)
+            .await
+            .map_err(|err| bad_request(format!("invalid query: {err}")))?;
+        value.validate().map_err(validation_error)?;
+        Ok(Self(value))
+    }
+}
+
+impl IntoResponse for ApiErrorResponse {
+    fn into_response(self) -> axum::response::Response {
+        Json(self).into_response()
+    }
+}

--- a/crates/alloy-server/src/lib.rs
+++ b/crates/alloy-server/src/lib.rs
@@ -19,6 +19,7 @@ use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 pub mod builder;
+pub mod api;
 pub mod grpc;
 pub mod middleware;
 pub use builder::AlloyServer;

--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -76,6 +76,43 @@ async fn get_note(
 
 See `/examples/simple-server/src/main.rs` for a runnable end-to-end example using these DTO styles.
 
+## Validation And Error DTO Pattern
+
+Alloy now includes reusable REST validation helpers:
+
+- `alloy_server::api::ValidatedJson<T>`
+- `alloy_server::api::ValidatedQuery<T>`
+- `alloy_server::api::ApiErrorResponse`
+
+Typical usage:
+
+```rust
+use alloy_server::api::{ApiError, ValidatedJson};
+use validator::Validate;
+
+#[derive(serde::Deserialize, Validate)]
+struct CreateNoteBody {
+    #[validate(length(min = 2, max = 120))]
+    title: String,
+}
+
+async fn create_note(
+    ValidatedJson(body): ValidatedJson<CreateNoteBody>,
+) -> Result<axum::Json<String>, ApiError> {
+    Ok(axum::Json(body.title))
+}
+```
+
+Validation failures return a structured `400` error JSON with:
+- `code`
+- `message`
+- `details` (field-level messages)
+
+## Depends-Like Extractor Pattern
+
+For FastAPI `Depends(...)` style injection, define a custom extractor via `FromRequestParts`.
+See `RequestContext` in `/examples/simple-server/src/main.rs` for a practical pattern.
+
 ## Notes
 
 - Default `AlloyServer::new()` enables both REST and gRPC on a single listener.

--- a/examples/simple-server/Cargo.toml
+++ b/examples/simple-server/Cargo.toml
@@ -9,4 +9,9 @@ alloy-core = { path = "../../crates/alloy-core" }
 alloy-server = { path = "../../crates/alloy-server" }
 axum.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 tokio.workspace = true
+validator.workspace = true
+
+[dev-dependencies]
+tower.workspace = true

--- a/examples/simple-server/src/main.rs
+++ b/examples/simple-server/src/main.rs
@@ -1,69 +1,101 @@
 use std::{net::SocketAddr, sync::Arc};
 
 use alloy_core::AppState;
-use alloy_server::AlloyServer;
+use alloy_server::{
+    api::{bad_request, ApiError, ValidatedJson, ValidatedQuery},
+    AlloyServer,
+};
 use axum::{
-    extract::{Path, Query, State},
+    extract::{FromRequestParts, Path, State},
+    http::request::Parts,
     routing::get,
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
+use validator::Validate;
 
 #[derive(Debug, Deserialize)]
 struct NotePath {
     id: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Validate)]
 struct NoteQuery {
+    #[validate(length(max = 80))]
     q: Option<String>,
+    #[validate(range(min = 1, max = 100))]
     limit: Option<u32>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Validate)]
 struct CreateNoteBody {
+    #[validate(length(min = 2, max = 120))]
     title: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct NoteResponse {
     id: String,
     title: String,
+    request_id: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct NotesListResponse {
     query: Option<String>,
     limit: u32,
 }
 
+#[derive(Debug, Clone)]
+struct RequestContext {
+    request_id: Option<String>,
+}
+
+#[axum::async_trait]
+impl<S> FromRequestParts<S> for RequestContext
+where
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let request_id = parts
+            .headers
+            .get("x-request-id")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        Ok(Self { request_id })
+    }
+}
+
 async fn get_note(
+    ctx: RequestContext,
     State(state): State<Arc<AppState>>,
     Path(path): Path<NotePath>,
-) -> Result<Json<NoteResponse>, (axum::http::StatusCode, String)> {
-    let title = state.greet(&path.id).map_err(|err| {
-        (
-            axum::http::StatusCode::BAD_REQUEST,
-            format!("validation error: {err}"),
-        )
-    })?;
+) -> Result<Json<NoteResponse>, ApiError> {
+    let title = state.greet(&path.id).map_err(|err| bad_request(err.to_string()))?;
     Ok(Json(NoteResponse {
         id: path.id,
         title,
+        request_id: ctx.request_id,
     }))
 }
 
-async fn list_notes(Query(query): Query<NoteQuery>) -> Json<NotesListResponse> {
+async fn list_notes(ValidatedQuery(query): ValidatedQuery<NoteQuery>) -> Json<NotesListResponse> {
     Json(NotesListResponse {
         query: query.q,
         limit: query.limit.unwrap_or(20),
     })
 }
 
-async fn create_note(Json(body): Json<CreateNoteBody>) -> Json<NoteResponse> {
+async fn create_note(
+    ctx: RequestContext,
+    ValidatedJson(body): ValidatedJson<CreateNoteBody>,
+) -> Json<NoteResponse> {
     Json(NoteResponse {
         id: "note-1".to_string(),
         title: body.title,
+        request_id: ctx.request_id,
     })
 }
 
@@ -85,4 +117,66 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .run()
         .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::to_bytes, http::Request};
+    use tower::util::ServiceExt;
+
+    fn app() -> Router {
+        let state = Arc::new(AppState::local("simple-server-test"));
+        Router::new()
+            .route("/notes", get(list_notes).post(create_note))
+            .route("/notes/:id", get(get_note))
+            .with_state(state)
+    }
+
+    #[tokio::test]
+    async fn invalid_body_returns_structured_400() {
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/notes")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(r#"{"title":"x"}"#))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let parsed: alloy_server::api::ApiErrorResponse =
+            serde_json::from_slice(&body).expect("api error json");
+        assert_eq!(parsed.code, "validation_error");
+    }
+
+    #[tokio::test]
+    async fn valid_body_returns_note() {
+        let response = app()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/notes")
+                    .header("content-type", "application/json")
+                    .header("x-request-id", "req-1")
+                    .body(axum::body::Body::from(r#"{"title":"My Note"}"#))
+                    .unwrap(),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let parsed: NoteResponse = serde_json::from_slice(&body).expect("note json");
+        assert_eq!(parsed.title, "My Note");
+        assert_eq!(parsed.request_id.as_deref(), Some("req-1"));
+    }
 }


### PR DESCRIPTION
## Summary
- add shared API error DTO and helper constructors in `alloy-server`
- add `ValidatedJson<T>` and `ValidatedQuery<T>` extractors with `validator` integration
- update `simple-server` example with validated DTOs, custom request-context extractor, and error response tests
- document FastAPI-like validation and dependency extractor usage

## Validation
- cargo test -p simple-server -q
- cargo test -p alloy-server -q
- cargo check --workspace -q

Closes #24
