### PR TITLE
feat(macros): add route attribute parser foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "alloy-rpc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-  "crates/alloy-core",
+  "crates/alloy-core", "crates/alloy-macros",
   "crates/alloy-rpc",
   "crates/alloy-server",
   "examples/simple-server",

--- a/crates/alloy-macros/Cargo.toml
+++ b/crates/alloy-macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "alloy-macros"
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full", "parsing"] }

--- a/crates/alloy-macros/src/lib.rs
+++ b/crates/alloy-macros/src/lib.rs
@@ -1,0 +1,139 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse::Parse, parse_macro_input, Error, Ident, ItemFn, LitStr, Token};
+
+struct RouteArgs {
+    method: RouteMethod,
+    path: LitStr,
+    auto_validate: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum RouteMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+}
+
+impl Parse for RouteArgs {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
+        let method_ident: Ident = input.parse()?;
+        let method = match method_ident.to_string().as_str() {
+            "get" => RouteMethod::Get,
+            "post" => RouteMethod::Post,
+            "put" => RouteMethod::Put,
+            "patch" => RouteMethod::Patch,
+            "delete" => RouteMethod::Delete,
+            _ => {
+                return Err(Error::new(
+                    method_ident.span(),
+                    "unsupported method; use one of: get, post, put, patch, delete",
+                ))
+            }
+        };
+        if input.is_empty() {
+            return Err(Error::new(method_ident.span(), "route path is required"));
+        }
+        input.parse::<Token![,]>()?;
+
+        let path: LitStr = input
+            .parse()
+            .map_err(|_| Error::new(input.span(), "route path must be a string literal"))?;
+
+        let mut auto_validate = false;
+        while !input.is_empty() {
+            input.parse::<Token![,]>()?;
+            let flag: Ident = input.parse()?;
+            match flag.to_string().as_str() {
+                "auto_validate" => auto_validate = true,
+                _ => {
+                    return Err(Error::new(
+                        flag.span(),
+                        format!("unknown flag `{}`", flag),
+                    ))
+                }
+            }
+        }
+
+        Ok(Self {
+            method,
+            path,
+            auto_validate,
+        })
+    }
+}
+
+#[proc_macro_attribute]
+pub fn route(args: TokenStream, item: TokenStream) -> TokenStream {
+    let parsed = parse_macro_input!(args as RouteArgs);
+    let item_fn = parse_macro_input!(item as ItemFn);
+    let _ = (parsed.method, parsed.path, parsed.auto_validate);
+
+    TokenStream::from(quote! { #item_fn })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_str;
+
+    #[test]
+    fn parses_method_path_and_auto_validate_flag() {
+        let parsed = parse_str::<RouteArgs>(r#"post, "/notes", auto_validate"#)
+            .expect("route args should parse");
+
+        assert_eq!(parsed.method, RouteMethod::Post);
+        assert_eq!(parsed.path.value(), "/notes");
+        assert!(parsed.auto_validate);
+    }
+
+    #[test]
+    fn parses_without_auto_validate() {
+        let parsed = parse_str::<RouteArgs>(r#"get, "/health""#)
+            .expect("route args should parse");
+
+        assert_eq!(parsed.method, RouteMethod::Get);
+        assert_eq!(parsed.path.value(), "/health");
+        assert!(!parsed.auto_validate);
+    }
+
+    #[test]
+    fn rejects_unsupported_method() {
+        let err = match parse_str::<RouteArgs>(r#"options, "/notes""#) {
+            Ok(_) => panic!("unsupported method must fail"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("unsupported method"));
+    }
+
+    #[test]
+    fn rejects_unknown_flag() {
+        let err = match parse_str::<RouteArgs>(r#"post, "/notes", unknown_flag"#) {
+            Ok(_) => panic!("unknown flag must fail"),
+            Err(err) => err,
+        };
+
+        let message = err.to_string();
+        assert!(message.contains("unknown flag"));
+    }
+
+    #[test]
+    fn rejects_missing_path() {
+        let err = match parse_str::<RouteArgs>("post") {
+            Ok(_) => panic!("missing path must fail"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("path"));
+    }
+
+    #[test]
+    fn rejects_non_string_path() {
+        let err = match parse_str::<RouteArgs>("post, 10") {
+            Ok(_) => panic!("non-string path must fail"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("string"));
+    }
+}


### PR DESCRIPTION
## Summary
- add new `crates/alloy-macros` proc-macro crate to workspace
- add `#[route(...)]` attribute macro scaffold and implement route-attribute parser
- parser supports: `method, "path"[, auto_validate]`
- parser validates supported methods (`get/post/put/patch/delete`) and rejects unknown flags

## Red -> Green -> Blue
- Red: added parser tests first and confirmed failures (`cargo test -p alloy-macros -q` failed)
- Green: implemented parser to pass parsing/validation tests
- Blue: refactored method parsing into enum with strict method validation and additional test coverage

## Validation
- cargo test -p alloy-macros -q
- cargo check --workspace -q

## Notes
- This PR intentionally delivers parser foundation first.
- Handler argument rewrite (`Json<T>` -> `ValidatedJson<T>`, `Query<T>` -> `ValidatedQuery<T>`) will be added in follow-up commits on this issue.

Closes #27
