### PR TITLE
feat: implement route(auto_validate) extractor rewriting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ name = "alloy-server"
 version = "0.1.0"
 dependencies = [
  "alloy-core",
+ "alloy-macros",
  "alloy-rpc",
  "axum",
  "http",

--- a/crates/alloy-server/Cargo.toml
+++ b/crates/alloy-server/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 alloy-core = { path = "../alloy-core" }
+alloy-macros = { path = "../alloy-macros" }
 alloy-rpc = { path = "../alloy-rpc" }
 axum.workspace = true
 tokio.workspace = true

--- a/crates/alloy-server/src/lib.rs
+++ b/crates/alloy-server/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate self as alloy_server;
+
 use std::sync::Arc;
 
 use alloy_core::{AlloyError, AppState};
@@ -18,10 +20,11 @@ use tonic::service::Routes;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-pub mod builder;
 pub mod api;
+pub mod builder;
 pub mod grpc;
 pub mod middleware;
+pub use alloy_macros::route;
 pub use builder::AlloyServer;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -56,7 +59,10 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .route("/health", get(health))
         .route("/hello/:name", get(hello))
         .route("/grpc/contracts", get(grpc_contracts_markdown))
-        .route("/grpc/contracts/openapi.json", get(grpc_contracts_openapi_bridge))
+        .route(
+            "/grpc/contracts/openapi.json",
+            get(grpc_contracts_openapi_bridge),
+        )
         .merge(SwaggerUi::new("/docs").url("/openapi.json", ApiDoc::openapi()))
         .with_state(state)
 }
@@ -160,7 +166,12 @@ mod tests {
     async fn health_returns_ok() {
         let app = build_router(Arc::new(AppState::local("test-server")));
         let response = app
-            .oneshot(Request::builder().uri("/health").body(axum::body::Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
             .await
             .expect("request should succeed");
 

--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -108,6 +108,28 @@ Validation failures return a structured `400` error JSON with:
 - `message`
 - `details` (field-level messages)
 
+## Auto-Validate Route Macro (FastAPI-Like DX)
+
+For a more FastAPI-like handler style, use `#[alloy_server::route(..., auto_validate)]`.
+
+With `auto_validate`, handler arguments are rewritten at compile time:
+- `Json<T>` -> `ValidatedJson<T>`
+- `Query<T>` -> `ValidatedQuery<T>`
+
+Example:
+
+```rust
+use alloy_server::api::ApiError;
+use axum::Json;
+
+#[alloy_server::route(post, "/notes", auto_validate)]
+async fn create_note(Json(body): Json<CreateNoteBody>) -> Result<Json<String>, ApiError> {
+    Ok(Json(body.title))
+}
+```
+
+If you omit `auto_validate`, behavior stays unchanged.
+
 ## Depends-Like Extractor Pattern
 
 For FastAPI `Depends(...)` style injection, define a custom extractor via `FromRequestParts`.


### PR DESCRIPTION
## Summary
- implement `#[alloy_server::route(..., auto_validate)]` argument rewriting
- rewrite `Json<T>` to `::alloy_server::api::ValidatedJson<T>`
- rewrite `Query<T>` to `::alloy_server::api::ValidatedQuery<T>`
- rewrite both type and tuple-struct pattern paths so handlers keep ergonomic `Json(body)` / `Query(q)` source style
- re-export macro from `alloy-server` via `pub use alloy_macros::route`
- add docs and simple-server coverage for opt-in behavior

## TDD (Red -> Green -> Blue)
- Red: added rewrite tests in `alloy-macros` and confirmed failing assertion
- Green: implemented AST rewrite for supported extractor forms
- Blue: stabilized rewrite via absolute path output and added runtime behavior tests in simple-server

## Behavior validated
- `auto_validate` returns structured 400 for invalid body/query inputs
- omitting `auto_validate` keeps original non-validating behavior

## Validation
- cargo test -p alloy-macros -q
- cargo test -p simple-server -q
- cargo check --workspace -q

## Note
Issue #27 is already closed by earlier foundation PR; this PR completes the runtime rewrite behavior originally planned there.
