### PR TITLE
feat: add SSE support with heartbeat for REST routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tower 0.5.3",
  "tower-http 0.5.2",
@@ -1693,6 +1694,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tower 0.5.3",
  "validator",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.1.0"
 [workspace.dependencies]
 axum = { version = "0.7", features = ["macros", "http2"] }
 tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Alloy is a Rust server framework focused on **FastAPI-like developer ergonomics*
 - gRPC contract bridge docs:
   - `/grpc/contracts`
   - `/grpc/contracts/openapi.json`
+- REST SSE stream:
+  - `/events`
 - Fluent server builder API:
   - `AlloyServer::new().with_...().run()`
 - Shared middleware stack:
@@ -38,6 +40,7 @@ ALLOY_SERVER_ADDR=127.0.0.1:4000 cargo run -p alloy-server
 ```bash
 curl -s http://127.0.0.1:3000/health
 curl -s http://127.0.0.1:3000/hello/Rust
+curl -N http://127.0.0.1:3000/events
 ```
 
 ### 3) Open docs

--- a/crates/alloy-server/Cargo.toml
+++ b/crates/alloy-server/Cargo.toml
@@ -10,6 +10,7 @@ alloy-macros = { path = "../alloy-macros" }
 alloy-rpc = { path = "../alloy-rpc" }
 axum.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 tonic.workspace = true
 tower.workspace = true
 tracing.workspace = true

--- a/crates/alloy-server/tests/multiplexing.rs
+++ b/crates/alloy-server/tests/multiplexing.rs
@@ -49,6 +49,21 @@ async fn serves_rest_and_grpc_on_single_port() {
     };
     assert_eq!(health_response.as_u16(), 200);
 
+    let events_response = rest_client
+        .get(format!("{base_url}/events"))
+        .send()
+        .await
+        .expect("sse endpoint should be reachable");
+    assert_eq!(events_response.status().as_u16(), 200);
+    let events_content_type = events_response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .expect("content-type header on sse")
+        .to_str()
+        .expect("content-type should be valid");
+    assert!(events_content_type.starts_with("text/event-stream"));
+    drop(events_response);
+
     let hello_response = rest_client
         .get(format!("{base_url}/hello/Rust"))
         .header("x-request-id", "rest-hello-id")

--- a/examples/simple-server/Cargo.toml
+++ b/examples/simple-server/Cargo.toml
@@ -11,6 +11,7 @@ axum.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 validator.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- add SSE endpoint `/events` to default `alloy-server` REST router
- implement typed SSE payload (`ServerSentEventPayload`) and heartbeat strategy
- include `KeepAlive` heartbeat comments to reduce idle disconnect risk
- add SSE route to `examples/simple-server` with event payload DTO and stream helper
- extend docs (`README.md`, `docs/fastapi-like-builder.md`) with SSE usage and reconnect/backoff guidance

## Red -> Green -> Blue
- Red: added SSE behavior tests (content-type + first heartbeat chunk) and single-port multiplexing SSE check
- Green: implemented SSE route, stream builder, keepalive, and example route
- Blue: hardened multiplexing test by explicitly dropping streaming response to avoid shutdown hangs

## Validation
- cargo test -p alloy-server -q
- cargo test -p simple-server -q
- cargo check --workspace -q
- cargo test --workspace -q

Closes #30
