### PR TITLE
feat: add WebSocket support with idle/message guardrails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,12 +56,14 @@ dependencies = [
  "alloy-macros",
  "alloy-rpc",
  "axum",
+ "futures-util",
  "http",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tonic",
  "tower 0.5.3",
  "tower-http 0.5.2",
@@ -141,6 +143,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "axum-macros",
+ "base64",
  "bytes",
  "futures-util",
  "http",
@@ -159,8 +162,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -225,6 +230,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -322,6 +333,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "derive_arbitrary"
@@ -442,6 +459,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +488,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -644,7 +674,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1438,7 +1468,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1643,6 +1673,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,10 +1732,12 @@ dependencies = [
  "alloy-core",
  "alloy-server",
  "axum",
+ "futures-util",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tower 0.5.3",
  "validator",
 ]
@@ -1917,6 +1960,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,6 +2186,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,6 +2246,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -2423,6 +2508,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ license = "MIT"
 version = "0.1.0"
 
 [workspace.dependencies]
-axum = { version = "0.7", features = ["macros", "http2"] }
+axum = { version = "0.7", features = ["macros", "http2", "ws"] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
+futures-util = "0.3"
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Alloy is a Rust server framework focused on **FastAPI-like developer ergonomics*
   - `/grpc/contracts/openapi.json`
 - REST SSE stream:
   - `/events`
+- REST WebSocket echo:
+  - `/ws`
 - Fluent server builder API:
   - `AlloyServer::new().with_...().run()`
 - Shared middleware stack:
@@ -41,7 +43,12 @@ ALLOY_SERVER_ADDR=127.0.0.1:4000 cargo run -p alloy-server
 curl -s http://127.0.0.1:3000/health
 curl -s http://127.0.0.1:3000/hello/Rust
 curl -N http://127.0.0.1:3000/events
+# ws check (requires websocat): websocat ws://127.0.0.1:3000/ws
 ```
+
+WebSocket defaults:
+- max text frame: `4096` bytes (`ALLOY_WS_MAX_TEXT_BYTES`)
+- idle timeout: `45` seconds (`ALLOY_WS_IDLE_TIMEOUT_SECS`)
 
 ### 3) Open docs
 

--- a/crates/alloy-server/Cargo.toml
+++ b/crates/alloy-server/Cargo.toml
@@ -9,6 +9,7 @@ alloy-core = { path = "../alloy-core" }
 alloy-macros = { path = "../alloy-macros" }
 alloy-rpc = { path = "../alloy-rpc" }
 axum.workspace = true
+futures-util.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
@@ -25,3 +26,4 @@ validator.workspace = true
 
 [dev-dependencies]
 reqwest.workspace = true
+tokio-tungstenite.workspace = true

--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -164,6 +164,29 @@ Client reconnect guidance:
 - Add small jitter to avoid synchronized reconnect spikes.
 - Resume with `Last-Event-ID` when your client stack supports it.
 
+## WebSocket Endpoint Pattern
+
+Alloy supports WebSocket upgrade handlers for bidirectional realtime flows.
+
+```rust
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use futures_util::SinkExt;
+
+async fn ws_echo(ws: WebSocketUpgrade) -> impl axum::response::IntoResponse {
+    ws.max_message_size(4096).on_upgrade(handle_ws)
+}
+
+async fn handle_ws(mut socket: WebSocket) {
+    while let Some(Ok(Message::Text(text))) = socket.recv().await {
+        let _ = socket.send(Message::Text(format!("echo: {text}"))).await;
+    }
+}
+```
+
+Server defaults in `alloy-server`:
+- max text frame bytes: `ALLOY_WS_MAX_TEXT_BYTES` (default `4096`)
+- idle timeout seconds: `ALLOY_WS_IDLE_TIMEOUT_SECS` (default `45`)
+
 ## Depends-Like Extractor Pattern
 
 For FastAPI `Depends(...)` style injection, define a custom extractor via `FromRequestParts`.

--- a/examples/simple-server/Cargo.toml
+++ b/examples/simple-server/Cargo.toml
@@ -15,4 +15,6 @@ tokio-stream.workspace = true
 validator.workspace = true
 
 [dev-dependencies]
+futures-util.workspace = true
+tokio-tungstenite.workspace = true
 tower.workspace = true


### PR DESCRIPTION
## Summary
- add WebSocket route `/ws` to default `alloy-server` router
- implement echo session with connection lifecycle handling (open/close/error)
- enforce operational defaults with env-configurable guardrails:
  - max text frame bytes: `ALLOY_WS_MAX_TEXT_BYTES` (default `4096`)
  - idle timeout seconds: `ALLOY_WS_IDLE_TIMEOUT_SECS` (default `45`)
- add `/ws` example route to `examples/simple-server`
- add handshake+echo integration coverage in both multiplexing test and simple-server test
- update docs/README with usage and runtime knobs

## Red -> Green -> Blue
- Red: added WS handshake+echo check to multiplexing test and confirmed failure (no `/ws` route)
- Green: implemented WS upgrade handler and echo loop
- Blue: added idle/message-size guardrails and env-based defaults, plus docs/tests cleanup

## Validation
- cargo test -p alloy-server -q
- cargo test -p simple-server -q
- cargo check --workspace -q

Closes #31
