### PR TITLE
feat(auth): shared JWT verification for REST and gRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
 name = "alloy-core"
 version = "0.1.0"
 dependencies = [
+ "jsonwebtoken",
  "serde",
  "thiserror 1.0.69",
 ]
@@ -58,6 +59,7 @@ dependencies = [
  "axum",
  "futures-util",
  "http",
+ "jsonwebtoken",
  "reqwest",
  "serde",
  "serde_json",
@@ -143,7 +145,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "axum-macros",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http",
@@ -203,6 +205,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -339,6 +353,15 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive_arbitrary"
@@ -696,7 +719,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -891,6 +914,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.7",
+ "pem",
+ "ring 0.16.20",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,6 +1052,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,6 +1112,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -1099,6 +1179,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1296,7 +1382,7 @@ dependencies = [
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
- "ring",
+ "ring 0.17.14",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
@@ -1439,7 +1525,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -1473,6 +1559,21 @@ dependencies = [
 
 [[package]]
 name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -1481,7 +1582,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -1545,7 +1646,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "once_cell",
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1568,9 +1669,9 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
- "ring",
+ "ring 0.17.14",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -1743,6 +1844,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1886,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1883,6 +2002,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1997,7 +2147,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -2231,6 +2381,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -2290,7 +2446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4b5ac679cc6dfc5ea3f2823b0291c777750ffd5e13b21137e0f7ac0e8f9617"
 dependencies = [
  "axum",
- "base64",
+ "base64 0.22.1",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -2529,6 +2685,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,6 +2708,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tokio-stream = "0.1"
 futures-util = "0.3"
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 serde = { version = "1", features = ["derive"] }
+jsonwebtoken = "8.3"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Alloy is a Rust server framework focused on **FastAPI-like developer ergonomics*
   - `/events`
 - REST WebSocket echo:
   - `/ws`
+- Optional REST auth-protected route:
+  - `/protected/whoami`
 - Fluent server builder API:
   - `AlloyServer::new().with_...().run()`
 - Shared middleware stack:
@@ -49,6 +51,13 @@ curl -N http://127.0.0.1:3000/events
 WebSocket defaults:
 - max text frame: `4096` bytes (`ALLOY_WS_MAX_TEXT_BYTES`)
 - idle timeout: `45` seconds (`ALLOY_WS_IDLE_TIMEOUT_SECS`)
+
+Auth defaults:
+- disabled by default (`ALLOY_AUTH_ENABLED=false`)
+- when enabled, JWT HMAC secret required (`ALLOY_AUTH_JWT_SECRET`)
+- optional issuer/audience checks:
+  - `ALLOY_AUTH_ISSUER`
+  - `ALLOY_AUTH_AUDIENCE`
 
 ### 3) Open docs
 

--- a/crates/alloy-core/Cargo.toml
+++ b/crates/alloy-core/Cargo.toml
@@ -5,5 +5,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+jsonwebtoken.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/alloy-core/src/auth.rs
+++ b/crates/alloy-core/src/auth.rs
@@ -1,0 +1,172 @@
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub struct JwtValidationConfig {
+    pub secret: String,
+    pub expected_issuer: Option<String>,
+    pub expected_audience: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthPrincipal {
+    pub subject: String,
+    pub issuer: Option<String>,
+    pub audience: Vec<String>,
+    pub scopes: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JwtClaims {
+    pub sub: String,
+    pub exp: usize,
+    #[serde(default)]
+    pub iss: Option<String>,
+    #[serde(default)]
+    pub aud: Option<AudienceClaim>,
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AudienceClaim {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl AudienceClaim {
+    fn into_vec(self) -> Vec<String> {
+        match self {
+            Self::One(value) => vec![value],
+            Self::Many(values) => values,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AuthError {
+    #[error("invalid token: {0}")]
+    InvalidToken(String),
+    #[error("issuer mismatch")]
+    IssuerMismatch,
+    #[error("audience mismatch")]
+    AudienceMismatch,
+}
+
+pub fn validate_bearer_jwt(
+    token: &str,
+    cfg: &JwtValidationConfig,
+) -> Result<AuthPrincipal, AuthError> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.validate_exp = true;
+    validation
+        .required_spec_claims
+        .extend(["sub".to_string(), "exp".to_string()]);
+
+    let token_data = decode::<JwtClaims>(
+        token,
+        &DecodingKey::from_secret(cfg.secret.as_bytes()),
+        &validation,
+    )
+    .map_err(|err| AuthError::InvalidToken(err.to_string()))?;
+
+    let claims = token_data.claims;
+    if let Some(expected) = cfg.expected_issuer.as_deref() {
+        if claims.iss.as_deref() != Some(expected) {
+            return Err(AuthError::IssuerMismatch);
+        }
+    }
+
+    let audience = claims.aud.map(AudienceClaim::into_vec).unwrap_or_default();
+    if let Some(expected) = cfg.expected_audience.as_deref() {
+        if !audience.iter().any(|value| value == expected) {
+            return Err(AuthError::AudienceMismatch);
+        }
+    }
+
+    let scopes = claims
+        .scope
+        .unwrap_or_default()
+        .split_whitespace()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    Ok(AuthPrincipal {
+        subject: claims.sub,
+        issuer: claims.iss,
+        audience,
+        scopes,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{encode, EncodingKey, Header};
+
+    fn issue_token(secret: &str, claims: &JwtClaims) -> String {
+        encode(
+            &Header::new(Algorithm::HS256),
+            claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .expect("token should encode")
+    }
+
+    fn base_claims() -> JwtClaims {
+        JwtClaims {
+            sub: "user-1".to_string(),
+            exp: 4_102_444_800,
+            iss: Some("https://issuer.local".to_string()),
+            aud: Some(AudienceClaim::One("alloy-api".to_string())),
+            scope: Some("read:notes write:notes".to_string()),
+        }
+    }
+
+    #[test]
+    fn validates_token_and_maps_principal() {
+        let secret = "dev-secret";
+        let token = issue_token(secret, &base_claims());
+        let cfg = JwtValidationConfig {
+            secret: secret.to_string(),
+            expected_issuer: Some("https://issuer.local".to_string()),
+            expected_audience: Some("alloy-api".to_string()),
+        };
+
+        let principal = validate_bearer_jwt(&token, &cfg).expect("token should validate");
+        assert_eq!(principal.subject, "user-1");
+        assert_eq!(principal.issuer.as_deref(), Some("https://issuer.local"));
+        assert!(principal.audience.iter().any(|aud| aud == "alloy-api"));
+        assert!(principal.scopes.iter().any(|scope| scope == "read:notes"));
+    }
+
+    #[test]
+    fn rejects_issuer_mismatch() {
+        let secret = "dev-secret";
+        let token = issue_token(secret, &base_claims());
+        let cfg = JwtValidationConfig {
+            secret: secret.to_string(),
+            expected_issuer: Some("https://other-issuer.local".to_string()),
+            expected_audience: None,
+        };
+
+        let err = validate_bearer_jwt(&token, &cfg).expect_err("issuer mismatch should fail");
+        assert!(matches!(err, AuthError::IssuerMismatch));
+    }
+
+    #[test]
+    fn rejects_audience_mismatch() {
+        let secret = "dev-secret";
+        let token = issue_token(secret, &base_claims());
+        let cfg = JwtValidationConfig {
+            secret: secret.to_string(),
+            expected_issuer: None,
+            expected_audience: Some("other-aud".to_string()),
+        };
+
+        let err = validate_bearer_jwt(&token, &cfg).expect_err("audience mismatch should fail");
+        assert!(matches!(err, AuthError::AudienceMismatch));
+    }
+}

--- a/crates/alloy-core/src/lib.rs
+++ b/crates/alloy-core/src/lib.rs
@@ -2,6 +2,8 @@ use std::sync::Arc;
 
 use thiserror::Error;
 
+pub mod auth;
+
 pub type AlloyResult<T> = Result<T, AlloyError>;
 
 #[derive(Debug, Clone)]

--- a/crates/alloy-server/Cargo.toml
+++ b/crates/alloy-server/Cargo.toml
@@ -25,5 +25,6 @@ http.workspace = true
 validator.workspace = true
 
 [dev-dependencies]
+jsonwebtoken.workspace = true
 reqwest.workspace = true
 tokio-tungstenite.workspace = true

--- a/crates/alloy-server/src/auth.rs
+++ b/crates/alloy-server/src/auth.rs
@@ -1,0 +1,188 @@
+use std::{env, str::FromStr};
+
+use alloy_core::auth::{validate_bearer_jwt, AuthPrincipal, JwtValidationConfig};
+use axum::{
+    extract::{Request, State},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use tonic::Status;
+
+use crate::api::ApiErrorResponse;
+
+#[derive(Debug, Clone)]
+pub struct AuthRuntimeConfig {
+    pub enabled: bool,
+    pub jwt_secret: Option<String>,
+    pub expected_issuer: Option<String>,
+    pub expected_audience: Option<String>,
+}
+
+impl Default for AuthRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            jwt_secret: None,
+            expected_issuer: None,
+            expected_audience: None,
+        }
+    }
+}
+
+impl AuthRuntimeConfig {
+    pub fn from_env() -> Self {
+        Self {
+            enabled: read_env_bool("ALLOY_AUTH_ENABLED").unwrap_or(false),
+            jwt_secret: env::var("ALLOY_AUTH_JWT_SECRET").ok(),
+            expected_issuer: env::var("ALLOY_AUTH_ISSUER").ok(),
+            expected_audience: env::var("ALLOY_AUTH_AUDIENCE").ok(),
+        }
+    }
+
+    fn jwt_validation_config(&self) -> Result<JwtValidationConfig, AuthRejection> {
+        let secret = self.jwt_secret.clone().ok_or_else(|| {
+            AuthRejection::Misconfigured("ALLOY_AUTH_JWT_SECRET is missing".to_string())
+        })?;
+
+        Ok(JwtValidationConfig {
+            secret,
+            expected_issuer: self.expected_issuer.clone(),
+            expected_audience: self.expected_audience.clone(),
+        })
+    }
+
+    pub fn authenticate_authorization_value_str(
+        &self,
+        auth_value: &str,
+    ) -> Result<AuthPrincipal, AuthRejection> {
+        if !self.enabled {
+            return Ok(AuthPrincipal {
+                subject: "anonymous".to_string(),
+                issuer: None,
+                audience: vec![],
+                scopes: vec![],
+            });
+        }
+        let token = parse_bearer_token(auth_value)?;
+        let validation_cfg = self.jwt_validation_config()?;
+        validate_bearer_jwt(token, &validation_cfg)
+            .map_err(|err| AuthRejection::InvalidToken(err.to_string()))
+    }
+
+    pub fn authenticate_header_value(
+        &self,
+        auth_value: Option<&HeaderValue>,
+    ) -> Result<AuthPrincipal, AuthRejection> {
+        if !self.enabled {
+            return Ok(AuthPrincipal {
+                subject: "anonymous".to_string(),
+                issuer: None,
+                audience: vec![],
+                scopes: vec![],
+            });
+        }
+
+        let value = auth_value
+            .ok_or(AuthRejection::MissingAuthorization)?
+            .to_str()
+            .map_err(|_| {
+                AuthRejection::InvalidToken("authorization header is invalid".to_string())
+            })?;
+
+        self.authenticate_authorization_value_str(value)
+    }
+
+    pub fn authenticate_headers(
+        &self,
+        headers: &HeaderMap,
+    ) -> Result<AuthPrincipal, AuthRejection> {
+        self.authenticate_header_value(headers.get(header::AUTHORIZATION))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum AuthRejection {
+    MissingAuthorization,
+    InvalidToken(String),
+    Misconfigured(String),
+}
+
+impl AuthRejection {
+    pub fn into_rest_response(self) -> Response {
+        match self {
+            Self::MissingAuthorization => (
+                StatusCode::UNAUTHORIZED,
+                Json(ApiErrorResponse {
+                    code: "unauthorized".to_string(),
+                    message: "missing bearer token".to_string(),
+                    details: None,
+                }),
+            )
+                .into_response(),
+            Self::InvalidToken(message) => (
+                StatusCode::UNAUTHORIZED,
+                Json(ApiErrorResponse {
+                    code: "unauthorized".to_string(),
+                    message,
+                    details: None,
+                }),
+            )
+                .into_response(),
+            Self::Misconfigured(message) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiErrorResponse {
+                    code: "internal_error".to_string(),
+                    message,
+                    details: None,
+                }),
+            )
+                .into_response(),
+        }
+    }
+
+    pub fn into_grpc_status(self) -> Status {
+        match self {
+            Self::MissingAuthorization => Status::unauthenticated("missing bearer token"),
+            Self::InvalidToken(message) => Status::unauthenticated(message),
+            Self::Misconfigured(message) => Status::internal(message),
+        }
+    }
+}
+
+pub async fn rest_auth_middleware(
+    State(cfg): State<AuthRuntimeConfig>,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    match cfg.authenticate_headers(req.headers()) {
+        Ok(principal) => {
+            if cfg.enabled {
+                req.extensions_mut().insert(principal);
+            }
+            next.run(req).await
+        }
+        Err(rejection) => rejection.into_rest_response(),
+    }
+}
+
+pub fn parse_bearer_token(value: &str) -> Result<&str, AuthRejection> {
+    let mut parts = value.splitn(2, ' ');
+    let scheme = parts.next().unwrap_or_default();
+    let token = parts.next().unwrap_or_default();
+
+    if !scheme.eq_ignore_ascii_case("bearer") || token.trim().is_empty() {
+        return Err(AuthRejection::InvalidToken(
+            "authorization header must be Bearer <token>".to_string(),
+        ));
+    }
+
+    Ok(token.trim())
+}
+
+fn read_env_bool(name: &str) -> Option<bool> {
+    env::var(name)
+        .ok()
+        .and_then(|raw| bool::from_str(raw.trim()).ok())
+}

--- a/crates/alloy-server/src/grpc.rs
+++ b/crates/alloy-server/src/grpc.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
+use crate::auth::AuthRuntimeConfig;
 use alloy_core::{AlloyError, AppState};
 use alloy_rpc::{build_hello_response, Greeter, GreeterServer, HelloRequest, HelloResponse};
-use tonic::{Request, Response, Status};
+use tonic::{service::interceptor::InterceptedService, Request, Response, Status};
 
 #[derive(Clone)]
 pub struct GreeterService {
@@ -21,18 +22,56 @@ impl Greeter for GreeterService {
         &self,
         request: Request<HelloRequest>,
     ) -> Result<Response<HelloResponse>, Status> {
-        let response = build_hello_response(&self.state, request.into_inner()).map_err(map_error)?;
+        let response =
+            build_hello_response(&self.state, request.into_inner()).map_err(map_error)?;
         Ok(Response::new(response))
     }
 }
 
-pub fn build_grpc_service(state: Arc<AppState>) -> GreeterServer<GreeterService> {
-    GreeterServer::new(GreeterService::new(state))
+pub fn build_grpc_service(
+    state: Arc<AppState>,
+) -> InterceptedService<GreeterServer<GreeterService>, GrpcAuthInterceptor> {
+    build_grpc_service_with_auth(state, AuthRuntimeConfig::from_env())
+}
+
+pub fn build_grpc_service_with_auth(
+    state: Arc<AppState>,
+    auth_cfg: AuthRuntimeConfig,
+) -> InterceptedService<GreeterServer<GreeterService>, GrpcAuthInterceptor> {
+    let service = GreeterServer::new(GreeterService::new(state));
+    InterceptedService::new(service, GrpcAuthInterceptor { auth_cfg })
 }
 
 fn map_error(err: AlloyError) -> Status {
     match err {
         AlloyError::Validation(message) => Status::invalid_argument(message),
         AlloyError::Internal(message) => Status::internal(message),
+    }
+}
+
+#[derive(Clone)]
+pub struct GrpcAuthInterceptor {
+    auth_cfg: AuthRuntimeConfig,
+}
+
+impl tonic::service::Interceptor for GrpcAuthInterceptor {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        if !self.auth_cfg.enabled {
+            return Ok(request);
+        }
+
+        let auth_value = request
+            .metadata()
+            .get("authorization")
+            .ok_or_else(|| Status::unauthenticated("missing bearer token"))?
+            .to_str()
+            .map_err(|_| Status::unauthenticated("authorization metadata is invalid"))?;
+
+        let principal = self
+            .auth_cfg
+            .authenticate_authorization_value_str(auth_value)
+            .map_err(|err| err.into_grpc_status())?;
+        request.extensions_mut().insert(principal);
+        Ok(request)
     }
 }

--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -187,6 +187,23 @@ Server defaults in `alloy-server`:
 - max text frame bytes: `ALLOY_WS_MAX_TEXT_BYTES` (default `4096`)
 - idle timeout seconds: `ALLOY_WS_IDLE_TIMEOUT_SECS` (default `45`)
 
+## OAuth2/OIDC JWT Auth Pattern
+
+Alloy includes shared JWT claim validation used by both REST and gRPC layers.
+
+Environment configuration:
+- `ALLOY_AUTH_ENABLED=true`
+- `ALLOY_AUTH_JWT_SECRET=<hmac-secret>`
+- optional: `ALLOY_AUTH_ISSUER=<issuer>`
+- optional: `ALLOY_AUTH_AUDIENCE=<audience>`
+
+When enabled:
+- REST protected route example: `GET /protected/whoami` (Bearer token required)
+- gRPC interceptor validates `authorization: Bearer <token>` metadata
+
+When disabled:
+- existing baseline routes continue without auth enforcement.
+
 ## Depends-Like Extractor Pattern
 
 For FastAPI `Depends(...)` style injection, define a custom extractor via `FromRequestParts`.


### PR DESCRIPTION
## Summary
- add shared JWT auth core in `alloy-core` (`AuthPrincipal`, claims mapping, validation config)
- add server auth runtime config and bearer parsing helpers in `alloy-server::auth`
- REST: add middleware-based auth gate for `/protected/whoami`
- gRPC: add interceptor-based auth gate using same shared auth core
- insert shared principal into request extensions for REST/gRPC
- add docs for auth env configuration and protected route behavior

## Behavior
- Auth is disabled by default (`ALLOY_AUTH_ENABLED=false`) to preserve existing baseline routes.
- When enabled, JWT HMAC secret is required (`ALLOY_AUTH_JWT_SECRET`).
- Optional issuer/audience constraints:
  - `ALLOY_AUTH_ISSUER`
  - `ALLOY_AUTH_AUDIENCE`

## Tests
- `alloy-core` auth validation unit tests
- `alloy-server` protected REST route tests (missing/valid token)
- multiplexing integration test for gRPC interceptor (missing token rejected, valid token accepted)

## Validation
- cargo test -p alloy-core -q
- cargo test -p alloy-server -q
- cargo check --workspace -q

Closes #32
