### PR TITLE
feat(dx): add Depends-style DI with request-scoped cache and overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Alloy is a Rust server framework focused on **FastAPI-like developer ergonomics*
   - `/protected/whoami`
 - Fluent server builder API:
   - `AlloyServer::new().with_...().run()`
+- Depends-style DI extractor with request cache:
+  - `alloy_server::di::Depends<T>`
 - Shared middleware stack:
   - tracing, request-id propagation, CORS, timeout, concurrency limit
 

--- a/crates/alloy-server/src/di.rs
+++ b/crates/alloy-server/src/di.rs
@@ -1,0 +1,246 @@
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use axum::{
+    extract::{FromRef, FromRequestParts},
+    http::{request::Parts, StatusCode},
+    Extension, Json, Router,
+};
+
+use crate::api::{ApiError, ApiErrorResponse};
+
+#[derive(Debug, Clone)]
+pub struct Depends<T>(pub T);
+
+#[derive(Debug, Clone)]
+pub struct DependencyOverride<T>(pub T);
+
+#[derive(Clone, Default)]
+struct DependencyCache {
+    values: Arc<Mutex<HashMap<TypeId, Box<dyn Any + Send + Sync>>>>,
+}
+
+impl DependencyCache {
+    fn get<T>(&self) -> Option<T>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        let guard = self.values.lock().ok()?;
+        guard
+            .get(&TypeId::of::<T>())
+            .and_then(|value| value.downcast_ref::<T>())
+            .cloned()
+    }
+
+    fn insert<T>(&mut self, value: T)
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        if let Ok(mut guard) = self.values.lock() {
+            guard.insert(TypeId::of::<T>(), Box::new(value));
+        }
+    }
+}
+
+#[axum::async_trait]
+impl<T, S> FromRequestParts<S> for Depends<T>
+where
+    T: FromRef<S> + Clone + Send + Sync + 'static,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        if let Some(cache) = parts.extensions.get::<DependencyCache>() {
+            if let Some(value) = cache.get::<T>() {
+                return Ok(Self(value));
+            }
+        }
+
+        let value = if let Some(override_value) = parts.extensions.get::<DependencyOverride<T>>() {
+            override_value.0.clone()
+        } else {
+            T::from_ref(state)
+        };
+
+        if let Some(cache) = parts.extensions.get_mut::<DependencyCache>() {
+            cache.insert(value.clone());
+        } else {
+            let mut cache = DependencyCache::default();
+            cache.insert(value.clone());
+            parts.extensions.insert(cache);
+        }
+
+        Ok(Self(value))
+    }
+}
+
+pub fn with_dependency_override<S, T>(router: Router<S>, value: T) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+    T: Clone + Send + Sync + 'static,
+{
+    router.layer(Extension(DependencyOverride(value)))
+}
+
+pub fn internal_di_error(message: impl Into<String>) -> ApiError {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ApiErrorResponse {
+            code: "internal_error".to_string(),
+            message: message.into(),
+            details: None,
+        }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::to_bytes, extract::State, http::Request, response::IntoResponse, routing::get,
+    };
+    use serde::Serialize;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use tower::util::ServiceExt;
+
+    #[derive(Clone)]
+    struct TestState {
+        label: String,
+        build_counter: Arc<AtomicUsize>,
+    }
+
+    #[derive(Clone)]
+    struct LabelDep {
+        label: String,
+    }
+
+    impl FromRef<TestState> for LabelDep {
+        fn from_ref(state: &TestState) -> Self {
+            state.build_counter.fetch_add(1, Ordering::SeqCst);
+            Self {
+                label: state.label.clone(),
+            }
+        }
+    }
+
+    #[derive(Serialize)]
+    struct DepResponse {
+        a: String,
+        b: String,
+    }
+
+    async fn dep_handler(
+        Depends(a): Depends<LabelDep>,
+        Depends(b): Depends<LabelDep>,
+    ) -> impl IntoResponse {
+        Json(DepResponse {
+            a: a.label,
+            b: b.label,
+        })
+    }
+
+    #[tokio::test]
+    async fn depends_uses_request_scoped_cache() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let state = TestState {
+            label: "state-value".to_string(),
+            build_counter: counter.clone(),
+        };
+        let app = Router::new()
+            .route("/dep", get(dep_handler))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dep")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let body = String::from_utf8(bytes.to_vec()).expect("utf8 body");
+        assert!(body.contains("state-value"));
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn depends_override_wins_over_state_resolution() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let state = TestState {
+            label: "state-value".to_string(),
+            build_counter: counter.clone(),
+        };
+        let app = with_dependency_override(
+            Router::new()
+                .route("/dep", get(dep_handler))
+                .with_state(state),
+            LabelDep {
+                label: "override-value".to_string(),
+            },
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dep")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let body = String::from_utf8(bytes.to_vec()).expect("utf8 body");
+        assert!(body.contains("override-value"));
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+    }
+
+    async fn state_observe_handler(
+        Depends(dep): Depends<LabelDep>,
+        State(state): State<TestState>,
+    ) -> impl IntoResponse {
+        Json(DepResponse {
+            a: dep.label,
+            b: state.label,
+        })
+    }
+
+    #[tokio::test]
+    async fn depends_is_backward_compatible_with_state_extractor() {
+        let state = TestState {
+            label: "state-value".to_string(),
+            build_counter: Arc::new(AtomicUsize::new(0)),
+        };
+        let app = Router::new()
+            .route("/dep", get(state_observe_handler))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dep")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+    }
+}

--- a/crates/alloy-server/src/lib.rs
+++ b/crates/alloy-server/src/lib.rs
@@ -26,6 +26,7 @@ use utoipa_swagger_ui::SwaggerUi;
 pub mod api;
 pub mod auth;
 pub mod builder;
+pub mod di;
 pub mod grpc;
 pub mod middleware;
 pub use alloy_macros::route;

--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -206,8 +206,36 @@ When disabled:
 
 ## Depends-Like Extractor Pattern
 
-For FastAPI `Depends(...)` style injection, define a custom extractor via `FromRequestParts`.
-See `RequestContext` in `/examples/simple-server/src/main.rs` for a practical pattern.
+For FastAPI `Depends(...)` style injection, use `alloy_server::di::Depends<T>`.
+`Depends<T>` resolves dependencies from state (`FromRef`) with request-scoped caching.
+
+```rust
+use std::sync::Arc;
+
+use alloy_core::AppState;
+use alloy_server::di::Depends;
+use axum::extract::FromRef;
+
+#[derive(Clone)]
+struct ServiceInfo {
+    service_name: String,
+}
+
+impl FromRef<Arc<AppState>> for ServiceInfo {
+    fn from_ref(state: &Arc<AppState>) -> Self {
+        Self {
+            service_name: state.config.service_name.clone(),
+        }
+    }
+}
+
+async fn handler(Depends(info): Depends<ServiceInfo>) -> String {
+    info.service_name
+}
+```
+
+Test override helper:
+- `alloy_server::di::with_dependency_override(router, value)`
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add `alloy_server::di::Depends<T>` extractor for FastAPI-like dependency injection ergonomics
- add request-scoped dependency cache (same dependency resolved once per request)
- add test helper `with_dependency_override(router, value)` for override-driven tests
- keep backward compatibility with existing extractor patterns (`State`, custom extractors)
- update simple-server example to use `Depends<ServiceInfo>` from state
- update docs and README with new DI usage

## Red -> Green -> Blue
- Red: added DI behavior tests for cache + override + compatibility
- Green: implemented `Depends<T>` extractor and cache/override plumbing
- Blue: integrated example/docs and re-validated workspace tests

## Tests
- unit/integration tests in `crates/alloy-server/src/di.rs`:
  - request-scoped cache behavior
  - override precedence behavior
  - compatibility with `State` extractor
- simple-server tests remain green with Depends integration

## Validation
- cargo test -p alloy-server -q
- cargo test -p simple-server -q
- cargo check --workspace -q

Closes #35
