### PR TITLE
feat(validation): expand auto_validate to Path and unify OpenAPI error schema

### DIFF
--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -108,6 +108,10 @@ Validation failures return a structured `400` error JSON with:
 - `message`
 - `details` (field-level messages)
 
+OpenAPI wiring:
+- shared error schema uses `ApiErrorResponse`
+- REST path annotations can reference the same response body for `400/401/500`
+
 ## Auto-Validate Route Macro (FastAPI-Like DX)
 
 For a more FastAPI-like handler style, use `#[alloy_server::route(..., auto_validate)]`.
@@ -115,6 +119,7 @@ For a more FastAPI-like handler style, use `#[alloy_server::route(..., auto_vali
 With `auto_validate`, handler arguments are rewritten at compile time:
 - `Json<T>` -> `ValidatedJson<T>`
 - `Query<T>` -> `ValidatedQuery<T>`
+- `Path<T>` -> `ValidatedPath<T>`
 
 Example:
 
@@ -129,6 +134,9 @@ async fn create_note(Json(body): Json<CreateNoteBody>) -> Result<Json<String>, A
 ```
 
 If you omit `auto_validate`, behavior stays unchanged.
+
+For header/cookie wrapper patterns, use `ValidatedParts<T>` with your custom parts extractor
+that implements `Validate`.
 
 ## SSE Endpoint Pattern
 


### PR DESCRIPTION
## Summary
- expand `#[alloy_server::route(..., auto_validate)]` rewriting to include `Path<T>`
  - `Path<T>` -> `ValidatedPath<T>`
- add new `ValidatedPath<T>` extractor in `alloy-server::api`
- add `ValidatedParts<T>` for header/cookie wrapper style parts extractors that implement `Validate`
- derive `utoipa::ToSchema` on `ApiErrorResponse` and wire shared error schema in OpenAPI components
- update REST path docs to reference `ApiErrorResponse` response bodies
- update simple-server example to use auto-validated path DTO and add invalid-path test

## Why
This extends validation coverage beyond body/query while preserving opt-in behavior (`auto_validate`) and keeps REST error schema representation consistent in OpenAPI.

## Tests
- macro tests verify `Path<T>` rewrite support
- simple-server runtime test verifies invalid path validation returns structured 400
- alloy-server OpenAPI test checks protected route + `ApiErrorResponse` schema presence

## Validation
- cargo test -p alloy-macros -q
- cargo test -p simple-server -q
- cargo test -p alloy-server -q
- cargo check --workspace -q

Closes #36
