### PR TITLE
feat(grpc-docs): render /grpc/contracts as HTML and add raw markdown endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ dependencies = [
  "futures-util",
  "http",
  "jsonwebtoken",
+ "pulldown-cmark",
  "reqwest",
  "serde",
  "serde_json",
@@ -528,6 +529,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1361,6 +1371,25 @@ name = "protoc-bin-vendored-win32"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quinn"
@@ -2425,6 +2454,12 @@ name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "8", features = ["axum"] }
 http = "1"
 validator = { version = "0.19", features = ["derive"] }
+pulldown-cmark = "0.13"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Alloy is a Rust server framework focused on **FastAPI-like developer ergonomics*
   - `/openapi.json`
   - `/docs`
 - gRPC contract bridge docs:
-  - `/grpc/contracts`
+  - `/grpc/contracts` (rendered HTML)
+  - `/grpc/contracts.md` (raw markdown)
   - `/grpc/contracts/openapi.json`
 - REST SSE stream:
   - `/events`
@@ -65,7 +66,9 @@ Auth defaults:
 
 - Swagger UI: [http://127.0.0.1:3000/docs](http://127.0.0.1:3000/docs)
 - OpenAPI JSON: [http://127.0.0.1:3000/openapi.json](http://127.0.0.1:3000/openapi.json)
-- gRPC contracts: [http://127.0.0.1:3000/grpc/contracts](http://127.0.0.1:3000/grpc/contracts)
+- gRPC contracts (rendered): [http://127.0.0.1:3000/grpc/contracts](http://127.0.0.1:3000/grpc/contracts)
+- gRPC contracts (markdown): [http://127.0.0.1:3000/grpc/contracts.md](http://127.0.0.1:3000/grpc/contracts.md)
+- gRPC OpenAPI bridge: [http://127.0.0.1:3000/grpc/contracts/openapi.json](http://127.0.0.1:3000/grpc/contracts/openapi.json)
 
 ## Repository Layout
 

--- a/crates/alloy-server/Cargo.toml
+++ b/crates/alloy-server/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 serde_json.workspace = true
 http.workspace = true
 validator.workspace = true
+pulldown-cmark.workspace = true
 
 [dev-dependencies]
 jsonwebtoken.workspace = true

--- a/crates/alloy-server/tests/multiplexing.rs
+++ b/crates/alloy-server/tests/multiplexing.rs
@@ -111,6 +111,39 @@ async fn serves_rest_and_grpc_on_single_port() {
         "application/json"
     );
 
+    let grpc_contracts_html_response = rest_client
+        .get(format!("{base_url}/grpc/contracts"))
+        .send()
+        .await
+        .expect("grpc contracts html should be reachable");
+    assert_eq!(grpc_contracts_html_response.status().as_u16(), 200);
+    let grpc_contracts_html_content_type = grpc_contracts_html_response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .expect("grpc contracts html content-type header")
+        .to_str()
+        .expect("grpc contracts html content-type value");
+    assert!(grpc_contracts_html_content_type.starts_with("text/html"));
+    let grpc_contracts_html_body = grpc_contracts_html_response
+        .text()
+        .await
+        .expect("grpc contracts html body");
+    assert!(grpc_contracts_html_body.contains("/grpc/contracts/openapi.json"));
+
+    let grpc_contracts_markdown_response = rest_client
+        .get(format!("{base_url}/grpc/contracts.md"))
+        .send()
+        .await
+        .expect("grpc contracts markdown should be reachable");
+    assert_eq!(grpc_contracts_markdown_response.status().as_u16(), 200);
+    let grpc_contracts_markdown_content_type = grpc_contracts_markdown_response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .expect("grpc contracts markdown content-type header")
+        .to_str()
+        .expect("grpc contracts markdown content-type value");
+    assert!(grpc_contracts_markdown_content_type.starts_with("text/markdown"));
+
     let grpc_bridge_response = rest_client
         .get(format!("{base_url}/grpc/contracts/openapi.json"))
         .send()

--- a/docs/grpc-contract-docs-strategy.md
+++ b/docs/grpc-contract-docs-strategy.md
@@ -46,7 +46,8 @@ Reproducible flow:
   - `docs/generated/grpc-contracts.md`
   - `docs/generated/grpc-openapi-bridge.json`
 - Runtime endpoints:
-  - `GET /grpc/contracts`
+  - `GET /grpc/contracts` (rendered HTML)
+  - `GET /grpc/contracts.md` (raw markdown)
   - `GET /grpc/contracts/openapi.json`
 
 ## Limitations


### PR DESCRIPTION
## Summary
- make `GET /grpc/contracts` return a rendered HTML page instead of raw markdown
- add `GET /grpc/contracts.md` for stable raw markdown access
- add cross-links in the rendered page to:
  - `/grpc/contracts`
  - `/grpc/contracts.md`
  - `/grpc/contracts/openapi.json`
  - `/docs`
- cache rendered HTML with `OnceLock` to avoid re-parsing markdown per request
- update docs and tests to match the new contract docs behavior

## Testing
- `cargo check --workspace`
- `cargo test -p alloy-server grpc_contract_docs_are_available -- --nocapture`
- `cargo test -p alloy-server --test multiplexing -- --nocapture`

Closes #42
