### PR TITLE
fix(auth): prevent 500 on /protected/whoami when auth is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Auth defaults:
 - optional issuer/audience checks:
   - `ALLOY_AUTH_ISSUER`
   - `ALLOY_AUTH_AUDIENCE`
+- `/protected/whoami` behavior:
+  - auth disabled: returns `200` with anonymous principal
+  - auth enabled: requires bearer JWT and returns `401` when missing/invalid
 
 ### 3) Open docs
 

--- a/crates/alloy-server/src/auth.rs
+++ b/crates/alloy-server/src/auth.rs
@@ -158,9 +158,7 @@ pub async fn rest_auth_middleware(
 ) -> Response {
     match cfg.authenticate_headers(req.headers()) {
         Ok(principal) => {
-            if cfg.enabled {
-                req.extensions_mut().insert(principal);
-            }
+            req.extensions_mut().insert(principal);
             next.run(req).await
         }
         Err(rejection) => rejection.into_rest_response(),

--- a/crates/alloy-server/tests/multiplexing.rs
+++ b/crates/alloy-server/tests/multiplexing.rs
@@ -95,6 +95,18 @@ async fn serves_rest_and_grpc_on_single_port() {
         .expect("swagger ui should be reachable");
     assert_eq!(docs_response.status().as_u16(), 200);
 
+    let whoami_response = rest_client
+        .get(format!("{base_url}/protected/whoami"))
+        .send()
+        .await
+        .expect("protected whoami should be reachable");
+    assert_eq!(whoami_response.status().as_u16(), 200);
+    let whoami_body = whoami_response
+        .text()
+        .await
+        .expect("protected whoami body should be readable");
+    assert!(whoami_body.contains("anonymous"));
+
     let openapi_response = rest_client
         .get(format!("{base_url}/openapi.json"))
         .send()


### PR DESCRIPTION
## Summary
- fix `rest_auth_middleware` to always inject `AuthPrincipal` into request extensions
- make `/protected/whoami` deterministic when auth is disabled (returns anonymous principal with `200`)
- keep auth-enabled behavior unchanged (`401` on missing/invalid token)
- add unit test for auth-disabled `/protected/whoami`
- expand multiplexing integration test to validate default auth-disabled behavior
- update OpenAPI response descriptions and README auth behavior docs

## Testing
- `cargo test -p alloy-server protected_route_returns_anonymous_when_auth_disabled -- --nocapture`
- `cargo test -p alloy-server protected_route_rejects_missing_token_when_auth_enabled -- --nocapture`
- `cargo test -p alloy-server --test multiplexing -- --nocapture`
- `cargo check --workspace`

Closes #43
