### PR TITLE
chore(prod): add production preflight gate and runbooks (#54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,31 @@ jobs:
 
       - name: Run cargo audit
         run: cargo audit
+
+  prod-preflight:
+    name: Production Preflight
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run production preflight gate
+        env:
+          MELD_PREFLIGHT_SECURE: "true"
+          MELD_PREFLIGHT_BOOT_SERVER: "true"
+          MELD_PREFLIGHT_BASE_URL: "http://127.0.0.1:3000"
+          MELD_AUTH_ENABLED: "true"
+          MELD_AUTH_JWT_SECRET: "ci-dev-secret"
+          MELD_AUTH_ISSUER: "https://issuer.local"
+          MELD_AUTH_AUDIENCE: "meld-api"
+          MELD_CORS_ALLOW_ORIGINS: "https://app.example.com"
+          MELD_TIMEOUT_SECONDS: "15"
+          MELD_REQUEST_BODY_LIMIT_BYTES: "1048576"
+          MELD_MAX_IN_FLIGHT_REQUESTS: "1024"
+        run: ./scripts/prod_preflight.sh

--- a/README.md
+++ b/README.md
@@ -214,6 +214,27 @@ This runs:
 - REST+gRPC multiplexing integration test
 - contract artifact drift check
 - OpenAPI route check
+- production preflight gate
+
+## Production Readiness Docs
+
+- `docs/production/deployment.md`
+- `docs/production/security.md`
+- `docs/production/observability.md`
+- `docs/production/runbook.md`
+
+Run production preflight locally:
+
+```bash
+MELD_PREFLIGHT_SECURE=true \
+MELD_PREFLIGHT_BOOT_SERVER=true \
+MELD_AUTH_ENABLED=true \
+MELD_AUTH_JWT_SECRET=replace-me \
+MELD_AUTH_ISSUER=https://issuer.local \
+MELD_AUTH_AUDIENCE=meld-api \
+MELD_CORS_ALLOW_ORIGINS=https://app.example.com \
+./scripts/prod_preflight.sh
+```
 
 ## Current Status
 

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -16,6 +16,9 @@ This project uses focused CI jobs so failures are clearly scoped:
 4. `Security Audit`
 - `cargo audit`
 
+5. `Production Preflight`
+- `./scripts/prod_preflight.sh` with secure-mode CI environment
+
 ## Local Equivalent
 
 Run:

--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -1,0 +1,74 @@
+# Production Deployment
+
+This guide describes minimum production deployment patterns for Meld.
+
+## Runtime Prerequisites
+
+- Rust binary built from `meld-server`
+- Port binding for your target address (default `127.0.0.1:3000`)
+- Reverse proxy / ingress for TLS termination
+
+## Required Environment Variables (Secure Baseline)
+
+- `MELD_AUTH_ENABLED=true`
+- `MELD_AUTH_JWT_SECRET=<strong-random-secret>`
+- `MELD_AUTH_ISSUER=<issuer-url>` (recommended)
+- `MELD_AUTH_AUDIENCE=<audience>` (recommended)
+- `MELD_CORS_ALLOW_ORIGINS=<comma-separated allowlist>`
+
+Recommended hardening:
+- `MELD_TIMEOUT_SECONDS=15` (or lower based on SLO)
+- `MELD_REQUEST_BODY_LIMIT_BYTES=1048576` (or stricter)
+- `MELD_MAX_IN_FLIGHT_REQUESTS=1024` (size to capacity)
+
+## Local Production-Like Run
+
+```bash
+MELD_SERVER_ADDR=127.0.0.1:3000 \
+MELD_AUTH_ENABLED=true \
+MELD_AUTH_JWT_SECRET=replace-me \
+MELD_AUTH_ISSUER=https://issuer.local \
+MELD_AUTH_AUDIENCE=meld-api \
+MELD_CORS_ALLOW_ORIGINS=https://app.example.com \
+cargo run -p meld-server
+```
+
+## Preflight Gate (Recommended Before Rollout)
+
+```bash
+MELD_PREFLIGHT_SECURE=true \
+MELD_PREFLIGHT_BOOT_SERVER=true \
+MELD_AUTH_ENABLED=true \
+MELD_AUTH_JWT_SECRET=replace-me \
+MELD_AUTH_ISSUER=https://issuer.local \
+MELD_AUTH_AUDIENCE=meld-api \
+MELD_CORS_ALLOW_ORIGINS=https://app.example.com \
+./scripts/prod_preflight.sh
+```
+
+## Systemd Example
+
+```ini
+[Unit]
+Description=Meld Server
+After=network.target
+
+[Service]
+WorkingDirectory=/opt/meld
+ExecStart=/opt/meld/meld-server
+Restart=always
+RestartSec=5
+Environment=MELD_SERVER_ADDR=0.0.0.0:3000
+Environment=MELD_AUTH_ENABLED=true
+Environment=MELD_AUTH_JWT_SECRET=replace-me
+Environment=MELD_CORS_ALLOW_ORIGINS=https://app.example.com
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Kubernetes Notes
+
+- Use readiness probe on `/health`
+- Put secrets in `Secret`, non-sensitive config in `ConfigMap`
+- Terminate TLS at ingress and forward to Meld over private network

--- a/docs/production/observability.md
+++ b/docs/production/observability.md
@@ -1,0 +1,48 @@
+# Observability Guide
+
+Meld includes basic observability primitives through middleware and tracing.
+
+## Built-in Signals
+
+- Structured logs via `tracing` / `tracing-subscriber`
+- Request ID propagation (`x-request-id`)
+- Health endpoint: `GET /health`
+- API contract endpoints:
+  - `GET /openapi.json`
+  - `GET /grpc/contracts`
+
+## Logging Baseline
+
+Set log level using standard Rust tracing environment:
+
+```bash
+RUST_LOG=info cargo run -p meld-server
+```
+
+For deeper diagnostics:
+
+```bash
+RUST_LOG=debug,meld_server=debug cargo run -p meld-server
+```
+
+## Runtime Verification
+
+Use preflight endpoint checks:
+
+```bash
+MELD_PREFLIGHT_BOOT_SERVER=true ./scripts/prod_preflight.sh
+```
+
+This validates:
+- `/health`
+- `/openapi.json`
+- `/grpc/contracts`
+
+## Recommended External Integrations
+
+- Centralized log sink (ELK, Loki, Cloud Logging)
+- Metrics pipeline via reverse-proxy/service mesh metrics
+- Alerting on:
+  - health endpoint failures
+  - auth failure spikes (401 / UNAUTHENTICATED trends)
+  - latency and saturation indicators

--- a/docs/production/runbook.md
+++ b/docs/production/runbook.md
@@ -1,0 +1,59 @@
+# Operations Runbook
+
+This runbook provides first-response steps for common production incidents.
+
+## 1) Service Not Reachable
+
+Checklist:
+- Confirm process is running
+- Confirm bind address (`MELD_SERVER_ADDR`)
+- Check `/health` through service endpoint
+- Check ingress / load balancer routing
+
+Commands:
+
+```bash
+curl -i http://127.0.0.1:3000/health
+```
+
+## 2) Auth Failures
+
+Symptoms:
+- REST `401 unauthorized`
+- gRPC `UNAUTHENTICATED`
+
+Checklist:
+- `MELD_AUTH_ENABLED=true`
+- JWT secret matches token signer
+- issuer/audience claims match runtime config
+
+## 3) Contract Endpoint Failures
+
+Symptoms:
+- `/openapi.json` unavailable
+- `/grpc/contracts` unavailable
+
+Checklist:
+- Validate startup logs for server initialization issues
+- Run preflight locally in same environment
+
+```bash
+MELD_PREFLIGHT_BOOT_SERVER=true ./scripts/prod_preflight.sh
+```
+
+## 4) Release Gate Before Rollout
+
+Execute:
+
+```bash
+MELD_PREFLIGHT_SECURE=true \
+MELD_PREFLIGHT_BOOT_SERVER=true \
+MELD_AUTH_ENABLED=true \
+MELD_AUTH_JWT_SECRET=replace-me \
+MELD_CORS_ALLOW_ORIGINS=https://app.example.com \
+./scripts/prod_preflight.sh
+```
+
+Rollback guideline:
+- If preflight has critical failures, stop rollout.
+- Revert to last known-good release and re-run preflight after configuration fixes.

--- a/docs/production/security.md
+++ b/docs/production/security.md
@@ -1,0 +1,51 @@
+# Security Baseline
+
+This page defines a practical secure baseline for deploying Meld.
+
+## Authentication
+
+Use JWT auth in production:
+
+- `MELD_AUTH_ENABLED=true`
+- `MELD_AUTH_JWT_SECRET` must be set
+- `MELD_AUTH_ISSUER` recommended
+- `MELD_AUTH_AUDIENCE` recommended
+
+If auth is disabled, protected routes are not enforcing identity and gRPC auth interceptor is bypassed.
+
+## CORS
+
+Do not use wildcard CORS in production:
+
+- Avoid `MELD_CORS_ALLOW_ORIGINS=*`
+- Use explicit allowlist:
+  - `MELD_CORS_ALLOW_ORIGINS=https://app.example.com,https://admin.example.com`
+
+## Request Hardening
+
+- Set request timeout: `MELD_TIMEOUT_SECONDS`
+- Set request body size limit: `MELD_REQUEST_BODY_LIMIT_BYTES`
+- Set concurrency cap: `MELD_MAX_IN_FLIGHT_REQUESTS`
+
+## Secret Management
+
+- Never commit JWT secrets to git
+- Rotate `MELD_AUTH_JWT_SECRET` regularly
+- Inject secrets via secret manager / runtime environment
+
+## Preflight Security Check
+
+Run before release:
+
+```bash
+MELD_PREFLIGHT_SECURE=true \
+MELD_PREFLIGHT_BOOT_SERVER=true \
+MELD_AUTH_ENABLED=true \
+MELD_AUTH_JWT_SECRET=replace-me \
+MELD_CORS_ALLOW_ORIGINS=https://app.example.com \
+./scripts/prod_preflight.sh
+```
+
+Expected behavior:
+- exits non-zero on critical failures
+- emits warnings for unsafe but non-fatal settings

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -4,26 +4,40 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-echo "[1/7] cargo fmt --all -- --check"
+echo "[1/8] cargo fmt --all -- --check"
 cargo fmt --all -- --check
 
-echo "[2/7] cargo clippy --workspace --all-targets -- -D warnings"
+echo "[2/8] cargo clippy --workspace --all-targets -- -D warnings"
 cargo clippy --workspace --all-targets -- -D warnings
 
-echo "[3/7] cargo check --workspace"
+echo "[3/8] cargo check --workspace"
 cargo check --workspace
 
-echo "[4/7] cargo test --workspace"
+echo "[4/8] cargo test --workspace"
 cargo test --workspace
 
-echo "[5/7] cargo test -p meld-server --test multiplexing -- --nocapture"
+echo "[5/8] cargo test -p meld-server --test multiplexing -- --nocapture"
 cargo test -p meld-server --test multiplexing -- --nocapture
 
-echo "[6/7] scripts/check_contracts_bundle.sh"
+echo "[6/8] scripts/check_contracts_bundle.sh"
 ./scripts/check_contracts_bundle.sh
 
-echo "[7/7] cargo test -p meld-server openapi_json_is_available -- --nocapture"
+echo "[7/8] cargo test -p meld-server openapi_json_is_available -- --nocapture"
 cargo test -p meld-server openapi_json_is_available -- --nocapture
+
+echo "[8/8] scripts/prod_preflight.sh"
+MELD_PREFLIGHT_SECURE=true \
+MELD_PREFLIGHT_BOOT_SERVER=true \
+MELD_PREFLIGHT_BASE_URL=http://127.0.0.1:3000 \
+MELD_AUTH_ENABLED=true \
+MELD_AUTH_JWT_SECRET=local-dev-secret \
+MELD_AUTH_ISSUER=https://issuer.local \
+MELD_AUTH_AUDIENCE=meld-api \
+MELD_CORS_ALLOW_ORIGINS=https://app.example.com \
+MELD_TIMEOUT_SECONDS=15 \
+MELD_REQUEST_BODY_LIMIT_BYTES=1048576 \
+MELD_MAX_IN_FLIGHT_REQUESTS=1024 \
+./scripts/prod_preflight.sh
 
 if cargo audit -V >/dev/null 2>&1; then
   echo "[optional] cargo audit"

--- a/scripts/prod_preflight.sh
+++ b/scripts/prod_preflight.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+MELD_PREFLIGHT_BASE_URL="${MELD_PREFLIGHT_BASE_URL:-http://127.0.0.1:3000}"
+MELD_PREFLIGHT_BOOT_SERVER="${MELD_PREFLIGHT_BOOT_SERVER:-false}"
+MELD_PREFLIGHT_SECURE="${MELD_PREFLIGHT_SECURE:-false}"
+MELD_PREFLIGHT_WAIT_SECONDS="${MELD_PREFLIGHT_WAIT_SECONDS:-20}"
+
+FAIL_COUNT=0
+WARN_COUNT=0
+SERVER_PID=""
+SERVER_LOG=""
+
+normalize_bool() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+is_truthy() {
+  case "$(normalize_bool "$1")" in
+    1|true|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+ok() {
+  printf '[OK] %s\n' "$1"
+}
+
+warn() {
+  WARN_COUNT=$((WARN_COUNT + 1))
+  printf '[WARN] %s\n' "$1"
+}
+
+fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf '[FAIL] %s\n' "$1"
+}
+
+cleanup() {
+  if [[ -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$SERVER_LOG" && -f "$SERVER_LOG" ]]; then
+    rm -f "$SERVER_LOG"
+  fi
+}
+
+wait_for_server() {
+  local base_url="$1"
+  local wait_seconds="$2"
+  local attempts=$((wait_seconds * 4))
+  local i
+  for i in $(seq 1 "$attempts"); do
+    if curl -fsS "$base_url/health" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+check_endpoint_status() {
+  local path="$1"
+  local expected="$2"
+  local url="${MELD_PREFLIGHT_BASE_URL}${path}"
+  local body
+  body="$(mktemp)"
+  local code
+  code="$(curl -sS -o "$body" -w '%{http_code}' "$url" || true)"
+  if [[ "$code" == "$expected" ]]; then
+    ok "endpoint $path returned $expected"
+  else
+    fail "endpoint $path returned $code (expected $expected)"
+    if [[ -s "$body" ]]; then
+      printf '[INFO] response body: %s\n' "$(cat "$body")"
+    fi
+  fi
+  rm -f "$body"
+}
+
+check_endpoint_content_type() {
+  local path="$1"
+  local expected_prefix="$2"
+  local url="${MELD_PREFLIGHT_BASE_URL}${path}"
+  local headers
+  headers="$(mktemp)"
+  curl -sS -D "$headers" -o /dev/null "$url" || true
+  local content_type
+  content_type="$(awk -F': ' 'tolower($1)=="content-type" {print $2}' "$headers" | tr -d '\r' | tail -n1)"
+  if [[ "$content_type" == "$expected_prefix"* ]]; then
+    ok "endpoint $path content-type is $content_type"
+  else
+    fail "endpoint $path content-type is '$content_type' (expected prefix '$expected_prefix')"
+  fi
+  rm -f "$headers"
+}
+
+check_runtime_config() {
+  if is_truthy "$MELD_PREFLIGHT_SECURE"; then
+    if is_truthy "${MELD_AUTH_ENABLED:-false}"; then
+      ok "secure mode: MELD_AUTH_ENABLED=true"
+    else
+      fail "secure mode requires MELD_AUTH_ENABLED=true"
+    fi
+
+    if [[ -n "${MELD_AUTH_JWT_SECRET:-}" ]]; then
+      ok "secure mode: MELD_AUTH_JWT_SECRET is set"
+    else
+      fail "secure mode requires MELD_AUTH_JWT_SECRET"
+    fi
+
+    if [[ -n "${MELD_AUTH_ISSUER:-}" ]]; then
+      ok "secure mode: MELD_AUTH_ISSUER is set"
+    else
+      warn "secure mode: MELD_AUTH_ISSUER is not set (issuer validation disabled)"
+    fi
+
+    if [[ -n "${MELD_AUTH_AUDIENCE:-}" ]]; then
+      ok "secure mode: MELD_AUTH_AUDIENCE is set"
+    else
+      warn "secure mode: MELD_AUTH_AUDIENCE is not set (audience validation disabled)"
+    fi
+  else
+    warn "secure mode is disabled (MELD_PREFLIGHT_SECURE=false)"
+  fi
+
+  local cors="${MELD_CORS_ALLOW_ORIGINS:-}"
+  if [[ -z "$cors" ]]; then
+    warn "MELD_CORS_ALLOW_ORIGINS is not set (cross-origin requests disabled by default)"
+  elif [[ "$cors" == "*" ]]; then
+    warn "MELD_CORS_ALLOW_ORIGINS='*' is unsafe for production"
+  else
+    ok "CORS allow list configured"
+  fi
+
+  if [[ -z "${MELD_TIMEOUT_SECONDS:-}" ]]; then
+    warn "MELD_TIMEOUT_SECONDS not set (default 15s applies)"
+  else
+    ok "MELD_TIMEOUT_SECONDS is set"
+  fi
+
+  if [[ -z "${MELD_REQUEST_BODY_LIMIT_BYTES:-}" ]]; then
+    warn "MELD_REQUEST_BODY_LIMIT_BYTES not set (default 1048576 applies)"
+  else
+    ok "MELD_REQUEST_BODY_LIMIT_BYTES is set"
+  fi
+}
+
+start_server_if_needed() {
+  if ! is_truthy "$MELD_PREFLIGHT_BOOT_SERVER"; then
+    return 0
+  fi
+
+  SERVER_LOG="$(mktemp)"
+  cargo run -p meld-server --bin meld-server >"$SERVER_LOG" 2>&1 &
+  SERVER_PID="$!"
+
+  if wait_for_server "$MELD_PREFLIGHT_BASE_URL" "$MELD_PREFLIGHT_WAIT_SECONDS"; then
+    ok "booted meld-server for endpoint checks ($MELD_PREFLIGHT_BASE_URL)"
+  else
+    fail "failed to boot meld-server within ${MELD_PREFLIGHT_WAIT_SECONDS}s"
+    if [[ -f "$SERVER_LOG" ]]; then
+      printf '[INFO] server log tail:\n'
+      tail -n 40 "$SERVER_LOG" || true
+    fi
+  fi
+}
+
+main() {
+  trap cleanup EXIT
+
+  check_runtime_config
+  start_server_if_needed
+
+  check_endpoint_status "/health" "200"
+  check_endpoint_status "/openapi.json" "200"
+  check_endpoint_content_type "/openapi.json" "application/json"
+  check_endpoint_status "/grpc/contracts" "200"
+  check_endpoint_content_type "/grpc/contracts" "text/html"
+
+  printf '\nSummary: fails=%d warnings=%d\n' "$FAIL_COUNT" "$WARN_COUNT"
+  if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Implements issue #54 by adding production runbooks and an executable production preflight gate.

### Added
- `docs/production/deployment.md`
- `docs/production/security.md`
- `docs/production/observability.md`
- `docs/production/runbook.md`
- `scripts/prod_preflight.sh`

### Updated
- `.github/workflows/ci.yml`
  - added `Production Preflight` CI job
- `scripts/ci_local.sh`
  - added production preflight step
- `README.md`
  - added production docs + local preflight usage
- `docs/ci-workflow.md`
  - documented production preflight CI job

## Preflight coverage
- secure-mode required auth/env checks
- unsafe config warnings (e.g. wildcard CORS)
- endpoint checks:
  - `/health`
  - `/openapi.json`
  - `/grpc/contracts`

The script exits non-zero on critical failures and prints actionable `[OK]/[WARN]/[FAIL]` diagnostics.

## Validation
- `cargo fmt --all -- --check`
- `MELD_PREFLIGHT_SECURE=true MELD_PREFLIGHT_BOOT_SERVER=true ... ./scripts/prod_preflight.sh`
- `./scripts/ci_local.sh`

Closes #54
