### PR TITLE
release: sync develop into main for v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Meld Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Publish Crates And Create Release
+    runs-on: ubuntu-latest
+    environment: release
+    concurrency:
+      group: release-${{ github.ref_name }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Ensure tag commit is reachable from main
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Tag $GITHUB_REF_NAME does not point to a commit on main."
+            exit 1
+          fi
+
+      - name: Validate release gates
+        run: |
+          set -euo pipefail
+          cargo fmt --all -- --check
+          cargo clippy --workspace --all-targets -- -D warnings
+          cargo test --workspace
+          ./scripts/check_contracts_bundle.sh
+          MELD_PREFLIGHT_SECURE=true \
+          MELD_PREFLIGHT_BOOT_SERVER=true \
+          MELD_PREFLIGHT_WAIT_SECONDS=120 \
+          MELD_PREFLIGHT_BASE_URL=http://127.0.0.1:3000 \
+          MELD_AUTH_ENABLED=true \
+          MELD_AUTH_JWT_SECRET=ci-release-secret \
+          MELD_AUTH_ISSUER=https://issuer.local \
+          MELD_AUTH_AUDIENCE=meld-api \
+          MELD_CORS_ALLOW_ORIGINS=https://app.example.com \
+          MELD_TIMEOUT_SECONDS=15 \
+          MELD_REQUEST_BODY_LIMIT_BYTES=1048576 \
+          MELD_MAX_IN_FLIGHT_REQUESTS=1024 \
+          ./scripts/prod_preflight.sh
+          ./scripts/release_dry_run.sh
+
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+            echo "CRATES_IO_TOKEN secret is required."
+            exit 1
+          fi
+
+          publish_with_retry() {
+            local crate="$1"
+            local attempt=1
+            local max_attempts=12
+
+            while (( attempt <= max_attempts )); do
+              local log_file
+              log_file="$(mktemp)"
+              echo "Publishing ${crate} (attempt ${attempt}/${max_attempts})"
+
+              if cargo publish -p "${crate}" --locked 2>&1 | tee "${log_file}"; then
+                rm -f "${log_file}"
+                return 0
+              fi
+
+              if grep -Eqi "already uploaded|already exists|previously published|crate version.*already exists" "${log_file}"; then
+                echo "${crate} is already published for this version; continuing."
+                rm -f "${log_file}"
+                return 0
+              fi
+
+              if grep -Eqi "no matching package named|failed to select a version for the requirement" "${log_file}"; then
+                if (( attempt < max_attempts )); then
+                  echo "Index propagation delay for ${crate}; retrying in 10s."
+                  rm -f "${log_file}"
+                  attempt=$((attempt + 1))
+                  sleep 10
+                  continue
+                fi
+              fi
+
+              echo "Failed to publish ${crate}."
+              rm -f "${log_file}"
+              return 1
+            done
+          }
+
+          publish_with_retry meld-core
+          publish_with_retry meld-macros
+          publish_with_retry meld-rpc
+          publish_with_retry meld-server
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-rc.') }}

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Validate publishability of release crates:
 The script performs `cargo publish --dry-run` for all release crates with temporary
 local `patch.crates-io` overrides to validate publish order before first index propagation.
 
+Automated release publishing is available via `.github/workflows/release.yml` and runs on `v*` tag pushes from `main`.
+
 ## Current Status
 
 Core roadmap items are implemented:

--- a/docs/release/publish-runbook.md
+++ b/docs/release/publish-runbook.md
@@ -51,6 +51,34 @@ cargo publish -p meld-rpc
 cargo publish -p meld-server
 ```
 
+## Automated GitHub Release Path (Recommended)
+
+This repository includes tag-driven automation in `.github/workflows/release.yml`.
+
+Prerequisites:
+- GitHub Actions secret: `CRATES_IO_TOKEN`
+- `release` environment configured with required reviewer(s)
+- protected `main` branch
+
+Execution:
+
+1. Merge `develop` into `main` through a PR.
+2. Tag from `main` and push:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+3. GitHub Actions will:
+- re-run release quality gates
+- publish crates in dependency order (`meld-core` -> `meld-macros` -> `meld-rpc` -> `meld-server`)
+- create/update GitHub release notes
+
+The workflow rejects tags that are not reachable from `main`.
+
 ## First Release Candidate Tag Procedure
 
 1. Ensure `develop` is green on CI and release checklist is complete.


### PR DESCRIPTION
## Summary
- sync `main` with latest `develop` release automation updates
- include tag-driven release workflow (`.github/workflows/release.yml`)
- include release runbook/readme updates for automated publish path

## Why
- `main` must contain release workflow and docs before cutting stable tag `v0.1.0`
- branch protection and release environment are already configured

## Next after merge
1. Tag from `main`: `v0.1.0`
2. Push tag: `git push origin v0.1.0`
3. GitHub Actions `Meld Release` workflow publishes crates and creates release notes
