### PR TITLE
feat(example): add production-grade reference service (#60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Workspace tests
         run: cargo test --workspace
 
+      - name: Production example tests
+        run: cargo test -p production-api -- --nocapture
+
   rest-grpc-e2e:
     name: REST gRPC E2E
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +69,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -170,6 +185,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -221,6 +239,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,12 +263,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -386,6 +437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +485,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -464,6 +524,28 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -511,6 +593,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -545,6 +639,34 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -576,9 +698,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -686,6 +810,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -696,10 +822,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
@@ -717,6 +858,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1066,6 +1216,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall 0.7.1",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1283,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "meld-app"
@@ -1324,6 +1505,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,7 +1528,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1425,6 +1612,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1692,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "production-api"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "home",
+ "meld-core",
+ "meld-server",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "tracing-subscriber",
+ "utoipa",
+ "validator",
 ]
 
 [[package]]
@@ -1770,6 +1982,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
 dependencies = [
  "bitflags",
 ]
@@ -2187,6 +2408,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2213,6 +2437,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -2225,10 +2452,207 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.13.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-postgres",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -2711,10 +3135,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-width"
@@ -2848,6 +3293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2895,6 +3346,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3028,6 +3485,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3044,9 +3511,27 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3067,6 +3552,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3104,6 +3604,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3116,6 +3622,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3125,6 +3637,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3152,6 +3670,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3161,6 +3685,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3176,6 +3706,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3185,6 +3721,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +248,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +275,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -991,6 +1020,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1752,7 @@ name = "production-api"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "home",
  "meld-core",
  "meld-server",
@@ -2472,6 +2526,7 @@ checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -2530,7 +2585,9 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx-core",
+ "sqlx-mysql",
  "sqlx-postgres",
+ "sqlx-sqlite",
  "syn",
  "tokio",
  "url",
@@ -2547,6 +2604,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -2567,6 +2625,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "rsa",
+ "serde",
  "sha1",
  "sha2",
  "smallvec",
@@ -2587,6 +2646,7 @@ dependencies = [
  "base64",
  "bitflags",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -2621,6 +2681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",
@@ -2630,6 +2691,7 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "percent-encoding",
+ "serde",
  "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
@@ -3504,10 +3566,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "crates/meld-core", "crates/meld-macros",
   "crates/meld-rpc",
   "crates/meld-server", "examples/meld-app",
+  "examples/production-api",
   "examples/simple-server",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ crates/meld-core     # domain, state, error model
 crates/meld-rpc      # proto, tonic codegen, grpc-docgen tool
 crates/meld-server   # REST + gRPC routing, middleware, builder API
 contracts/           # explicit REST <-> gRPC mapping definitions
+examples/production-api
 examples/simple-server
 examples/meld-app
 docs/
@@ -175,6 +176,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 See:
 - `docs/fastapi-like-builder.md`
 - `docs/dx-scorecard.md`
+- `examples/production-api/README.md`
+- `examples/production-api/src/main.rs`
 - `examples/simple-server/README.md`
 - `examples/simple-server/src/main.rs`
 - `examples/meld-app/src/main.rs` (dependency-rename-safe macro usage)
@@ -222,6 +225,7 @@ This runs:
 - `docs/production/security.md`
 - `docs/production/observability.md`
 - `docs/production/runbook.md`
+- `docs/production/production-api-runbook.md`
 
 Run production preflight locally:
 

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -5,6 +5,7 @@ This project uses focused CI jobs so failures are clearly scoped:
 1. `Core Build And Test`
 - `cargo check --workspace`
 - `cargo test --workspace`
+- `cargo test -p production-api -- --nocapture`
 
 2. `REST gRPC E2E`
 - `cargo test -p meld-server --test multiplexing -- --nocapture`

--- a/docs/production/production-api-runbook.md
+++ b/docs/production/production-api-runbook.md
@@ -1,0 +1,122 @@
+# production-api Runbook
+
+This runbook covers local boot, migration behavior, smoke tests, and dependency failure recovery for `examples/production-api`.
+
+## Environment Variables
+
+Required:
+
+- `PROD_API_DATABASE_URL` (for example `postgres://postgres:postgres@127.0.0.1:55432/meld`)
+
+Optional (defaults shown):
+
+- `PROD_API_ADDR=127.0.0.1:4100`
+- `PROD_API_SERVICE_NAME=production-api`
+- `PROD_API_DB_MAX_CONNECTIONS=10`
+- `PROD_API_RUN_MIGRATIONS=true`
+- `PROD_API_MIGRATION_RETRY_SECONDS=5`
+
+Auth-related (recommended for realistic production flow):
+
+- `MELD_AUTH_ENABLED=true`
+- `MELD_AUTH_JWT_SECRET=<secret>`
+- `MELD_AUTH_ISSUER=<issuer>`
+- `MELD_AUTH_AUDIENCE=<audience>`
+
+## Boot Procedure
+
+1. Start PostgreSQL:
+
+```bash
+docker compose -f examples/production-api/docker-compose.yml up -d
+```
+
+2. Export env vars and start API:
+
+```bash
+export PROD_API_DATABASE_URL='postgres://postgres:postgres@127.0.0.1:55432/meld'
+export MELD_AUTH_ENABLED='true'
+export MELD_AUTH_JWT_SECRET='dev-secret'
+export MELD_AUTH_ISSUER='https://issuer.local'
+export MELD_AUTH_AUDIENCE='meld-api'
+
+cargo run -p production-api
+```
+
+3. Verify probes:
+
+```bash
+curl -s http://127.0.0.1:4100/livez
+curl -s http://127.0.0.1:4100/health
+curl -i http://127.0.0.1:4100/readyz
+```
+
+## Migration Behavior
+
+- Migrations are loaded from `examples/production-api/migrations`.
+- On startup, migration execution runs in a retry loop when `PROD_API_RUN_MIGRATIONS=true`.
+- If DB is temporarily unavailable, the service remains up and retries migrations every `PROD_API_MIGRATION_RETRY_SECONDS` seconds.
+
+## Smoke Tests
+
+REST:
+
+```bash
+curl -s -X POST http://127.0.0.1:4100/v1/notes \
+  -H 'content-type: application/json' \
+  -d '{"title":"hello","body":"world"}'
+
+curl -s 'http://127.0.0.1:4100/v1/notes?limit=5'
+```
+
+gRPC:
+
+```bash
+TOKEN=$(python3 scripts/generate_dev_jwt.py \
+  --secret dev-secret \
+  --issuer https://issuer.local \
+  --audience meld-api)
+
+grpcurl -plaintext \
+  -H "authorization: Bearer ${TOKEN}" \
+  -import-path crates/meld-rpc/proto \
+  -proto service.proto \
+  -d '{"name":"Rust"}' \
+  127.0.0.1:4100 \
+  meld.v1.Greeter/SayHello
+```
+
+## Failure Recovery
+
+Scenario: PostgreSQL outage.
+
+1. Simulate outage:
+
+```bash
+docker compose -f examples/production-api/docker-compose.yml stop postgres
+```
+
+2. Observe readiness failure (`503`):
+
+```bash
+curl -i http://127.0.0.1:4100/readyz
+```
+
+3. Recover DB:
+
+```bash
+docker compose -f examples/production-api/docker-compose.yml start postgres
+```
+
+4. Confirm readiness returns `200`.
+
+If readiness does not recover:
+- verify DB container health (`docker ps` / `docker logs`)
+- verify `PROD_API_DATABASE_URL`
+- verify migrations path and logs for migration retry errors
+
+## Shutdown
+
+```bash
+docker compose -f examples/production-api/docker-compose.yml down -v
+```

--- a/examples/production-api/.env.example
+++ b/examples/production-api/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to .env.local and set local-only secrets.
+PROD_API_DB_USER=postgres
+PROD_API_DB_PASSWORD=replace-with-local-only-value
+PROD_API_DB_NAME=meld
+
+MELD_AUTH_ENABLED=true
+MELD_AUTH_JWT_SECRET=replace-with-local-only-jwt-secret
+MELD_AUTH_ISSUER=https://issuer.local
+MELD_AUTH_AUDIENCE=meld-api

--- a/examples/production-api/.gitignore
+++ b/examples/production-api/.gitignore
@@ -1,0 +1,1 @@
+.env.local

--- a/examples/production-api/Cargo.toml
+++ b/examples/production-api/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "production-api"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+meld-core = { path = "../../crates/meld-core" }
+meld-server = { path = "../../crates/meld-server" }
+axum.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+validator.workspace = true
+utoipa.workspace = true
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "macros", "migrate"] }
+# Keep CI/local toolchain (Rust 1.86) compatible with sqlx transitive requirements.
+home = "=0.5.11"
+
+[dev-dependencies]
+tower.workspace = true

--- a/examples/production-api/Cargo.toml
+++ b/examples/production-api/Cargo.toml
@@ -16,7 +16,8 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 validator.workspace = true
 utoipa.workspace = true
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "macros", "migrate"] }
+chrono = { version = "0.4", features = ["serde"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "macros", "migrate", "chrono"] }
 # Keep CI/local toolchain (Rust 1.86) compatible with sqlx transitive requirements.
 home = "=0.5.11"
 

--- a/examples/production-api/README.md
+++ b/examples/production-api/README.md
@@ -1,0 +1,154 @@
+# production-api
+
+Production-oriented reference example for Meld.
+
+This example demonstrates:
+- explicit env configuration validation
+- PostgreSQL-backed REST endpoints
+- auth-protected REST route (`/protected/*`)
+- liveness/health/readiness probes
+- single-port REST + gRPC serving
+
+## Prerequisites
+
+- Docker + Docker Compose
+- `grpcurl`
+- `python3` (for local dev JWT helper)
+
+## 1) Start PostgreSQL
+
+From repository root:
+
+```bash
+docker compose -f examples/production-api/docker-compose.yml up -d
+```
+
+## 2) Run server
+
+```bash
+export PROD_API_DATABASE_URL='postgres://postgres:postgres@127.0.0.1:55432/meld'
+export PROD_API_ADDR='127.0.0.1:4100'
+export PROD_API_SERVICE_NAME='production-api'
+export PROD_API_RUN_MIGRATIONS='true'
+
+# auth enabled for protected REST + gRPC
+export MELD_AUTH_ENABLED='true'
+export MELD_AUTH_JWT_SECRET='dev-secret'
+export MELD_AUTH_ISSUER='https://issuer.local'
+export MELD_AUTH_AUDIENCE='meld-api'
+
+cargo run -p production-api
+```
+
+## 3) Probe endpoints
+
+```bash
+curl -s http://127.0.0.1:4100/livez
+curl -s http://127.0.0.1:4100/health
+curl -s -i http://127.0.0.1:4100/readyz
+```
+
+## 4) DB-backed REST smoke test
+
+```bash
+curl -s -X POST http://127.0.0.1:4100/v1/notes \
+  -H 'content-type: application/json' \
+  -d '{"title":"Production note","body":"hello"}'
+
+curl -s 'http://127.0.0.1:4100/v1/notes?limit=10'
+```
+
+## 5) Auth-protected REST path
+
+Without token (expected `401`):
+
+```bash
+curl -i http://127.0.0.1:4100/protected/notes/1
+```
+
+Create dev token:
+
+```bash
+TOKEN=$(python3 scripts/generate_dev_jwt.py \
+  --secret dev-secret \
+  --issuer https://issuer.local \
+  --audience meld-api)
+```
+
+Call with token (expected `200` when note exists):
+
+```bash
+curl -s http://127.0.0.1:4100/protected/notes/1 \
+  -H "authorization: Bearer ${TOKEN}"
+```
+
+## 6) gRPC call path on same port
+
+Without token (expected `UNAUTHENTICATED`):
+
+```bash
+grpcurl -plaintext \
+  -import-path crates/meld-rpc/proto \
+  -proto service.proto \
+  -d '{"name":"Rust"}' \
+  127.0.0.1:4100 \
+  meld.v1.Greeter/SayHello
+```
+
+With token (expected success):
+
+```bash
+grpcurl -plaintext \
+  -H "authorization: Bearer ${TOKEN}" \
+  -import-path crates/meld-rpc/proto \
+  -proto service.proto \
+  -d '{"name":"Rust"}' \
+  127.0.0.1:4100 \
+  meld.v1.Greeter/SayHello
+```
+
+## Failure Recovery Basics
+
+1. Stop PostgreSQL:
+
+```bash
+docker compose -f examples/production-api/docker-compose.yml stop postgres
+```
+
+2. Readiness should fail (`503`):
+
+```bash
+curl -i http://127.0.0.1:4100/readyz
+```
+
+3. Start PostgreSQL again:
+
+```bash
+docker compose -f examples/production-api/docker-compose.yml start postgres
+```
+
+4. Readiness should recover (`200`):
+
+```bash
+curl -i http://127.0.0.1:4100/readyz
+```
+
+## Troubleshooting
+
+- `missing required environment variable: PROD_API_DATABASE_URL`
+  - Set `PROD_API_DATABASE_URL` before running.
+- `401 unauthorized` on `/protected/*`
+  - Verify `MELD_AUTH_ENABLED`, `MELD_AUTH_JWT_SECRET`, `MELD_AUTH_ISSUER`, `MELD_AUTH_AUDIENCE`.
+  - Recreate token with `scripts/generate_dev_jwt.py`.
+- `UNAUTHENTICATED` in gRPC call
+  - Confirm `authorization: Bearer <token>` metadata and issuer/audience match.
+- `503` from `/readyz`
+  - Check PostgreSQL container health and DB URL host/port/database credentials.
+- `relation \"notes\" does not exist`
+  - Ensure migrations are enabled (`PROD_API_RUN_MIGRATIONS=true`) and wait for migration retry logs to succeed.
+
+## Shutdown / Cleanup
+
+```bash
+docker compose -f examples/production-api/docker-compose.yml down -v
+```

--- a/examples/production-api/docker-compose.yml
+++ b/examples/production-api/docker-compose.yml
@@ -4,13 +4,17 @@ services:
     container_name: meld-production-api-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: meld
+      POSTGRES_USER: ${PROD_API_DB_USER:-postgres}
+      POSTGRES_PASSWORD: ${PROD_API_DB_PASSWORD:?set_in_env_file}
+      POSTGRES_DB: ${PROD_API_DB_NAME:-meld}
     ports:
       - "55432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d meld"]
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${PROD_API_DB_USER:-postgres} -d ${PROD_API_DB_NAME:-meld}",
+        ]
       interval: 5s
       timeout: 3s
       retries: 20

--- a/examples/production-api/docker-compose.yml
+++ b/examples/production-api/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: meld-production-api-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: meld
+    ports:
+      - "55432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d meld"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    volumes:
+      - meld-prod-api-pgdata:/var/lib/postgresql/data
+
+volumes:
+  meld-prod-api-pgdata:

--- a/examples/production-api/migrations/0001_create_notes.sql
+++ b/examples/production-api/migrations/0001_create_notes.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS notes (
+    id BIGSERIAL PRIMARY KEY,
+    title TEXT NOT NULL,
+    body TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/examples/production-api/migrations/0002_add_owner_subject.sql
+++ b/examples/production-api/migrations/0002_add_owner_subject.sql
@@ -1,0 +1,11 @@
+ALTER TABLE notes
+ADD COLUMN IF NOT EXISTS owner_subject TEXT;
+
+UPDATE notes
+SET owner_subject = 'legacy'
+WHERE owner_subject IS NULL;
+
+ALTER TABLE notes
+ALTER COLUMN owner_subject SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS notes_owner_subject_id_idx ON notes(owner_subject, id DESC);

--- a/examples/production-api/src/main.rs
+++ b/examples/production-api/src/main.rs
@@ -464,7 +464,7 @@ mod tests {
     fn config_uses_defaults_when_optional_values_absent() {
         let cfg = ProductionConfig::from_lookup(|key| {
             if key == "PROD_API_DATABASE_URL" {
-                Some("postgres://postgres:postgres@127.0.0.1:55432/meld".to_string())
+                Some("postgres://127.0.0.1:55432/meld".to_string())
             } else {
                 None
             }
@@ -482,7 +482,7 @@ mod tests {
     async fn readyz_returns_503_when_database_is_unavailable() {
         let pool = PgPoolOptions::new()
             .max_connections(1)
-            .connect_lazy("postgres://postgres:postgres@127.0.0.1:1/meld")
+            .connect_lazy("postgres://127.0.0.1:1/meld")
             .expect("lazy pool should build");
 
         let state = Arc::new(ProductionApiState::new(

--- a/examples/production-api/src/main.rs
+++ b/examples/production-api/src/main.rs
@@ -1,0 +1,506 @@
+use std::{env, error::Error, fmt, net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
+
+use axum::{
+    extract::{Extension, State},
+    http::StatusCode,
+    middleware::from_fn_with_state,
+    routing::get,
+    Json, Router,
+};
+use meld_core::{auth::AuthPrincipal, AppState};
+use meld_server::{
+    api::{ApiError, ApiErrorResponse},
+    auth::{self, AuthRuntimeConfig},
+    MeldServer,
+};
+use serde::Serialize;
+use sqlx::{postgres::PgPoolOptions, FromRow, PgPool};
+use tracing_subscriber::EnvFilter;
+
+#[derive(Debug, Clone)]
+struct ProductionConfig {
+    addr: SocketAddr,
+    service_name: String,
+    database_url: String,
+    max_db_connections: u32,
+    run_migrations: bool,
+    migration_retry_seconds: u64,
+}
+
+#[derive(Debug)]
+enum ConfigError {
+    MissingRequired {
+        key: &'static str,
+    },
+    InvalidValue {
+        key: &'static str,
+        value: String,
+        reason: String,
+    },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingRequired { key } => {
+                write!(f, "missing required environment variable: {key}")
+            }
+            Self::InvalidValue { key, value, reason } => {
+                write!(f, "invalid value for {key}='{value}': {reason}")
+            }
+        }
+    }
+}
+
+impl Error for ConfigError {}
+
+impl ProductionConfig {
+    fn from_env() -> Result<Self, ConfigError> {
+        Self::from_lookup(|key| env::var(key).ok())
+    }
+
+    fn from_lookup<F>(mut lookup: F) -> Result<Self, ConfigError>
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        let addr = parse_or_default(
+            &mut lookup,
+            "PROD_API_ADDR",
+            SocketAddr::from(([127, 0, 0, 1], 4100)),
+        )?;
+
+        let service_name = lookup("PROD_API_SERVICE_NAME")
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| "production-api".to_string());
+
+        let database_url = required_value(&mut lookup, "PROD_API_DATABASE_URL")?;
+        let max_db_connections = parse_or_default(&mut lookup, "PROD_API_DB_MAX_CONNECTIONS", 10)?;
+        let run_migrations = parse_or_default(&mut lookup, "PROD_API_RUN_MIGRATIONS", true)?;
+        let migration_retry_seconds =
+            parse_or_default(&mut lookup, "PROD_API_MIGRATION_RETRY_SECONDS", 5)?;
+
+        Ok(Self {
+            addr,
+            service_name,
+            database_url,
+            max_db_connections,
+            run_migrations,
+            migration_retry_seconds,
+        })
+    }
+}
+
+fn required_value<F>(lookup: &mut F, key: &'static str) -> Result<String, ConfigError>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    match lookup(key).map(|value| value.trim().to_string()) {
+        Some(value) if !value.is_empty() => Ok(value),
+        _ => Err(ConfigError::MissingRequired { key }),
+    }
+}
+
+fn parse_or_default<T, F>(lookup: &mut F, key: &'static str, default: T) -> Result<T, ConfigError>
+where
+    T: FromStr,
+    <T as FromStr>::Err: fmt::Display,
+    F: FnMut(&str) -> Option<String>,
+{
+    match lookup(key) {
+        Some(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return Err(ConfigError::InvalidValue {
+                    key,
+                    value: raw,
+                    reason: "value must not be empty".to_string(),
+                });
+            }
+
+            trimmed
+                .parse::<T>()
+                .map_err(|err| ConfigError::InvalidValue {
+                    key,
+                    value: raw,
+                    reason: err.to_string(),
+                })
+        }
+        None => Ok(default),
+    }
+}
+
+#[derive(Clone)]
+struct ProductionApiState {
+    service_name: String,
+    pool: PgPool,
+}
+
+impl ProductionApiState {
+    fn new(service_name: String, pool: PgPool) -> Self {
+        Self { service_name, pool }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct StatusResponse {
+    status: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    service: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ReadyResponse {
+    status: &'static str,
+    database: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct NoteResponse {
+    id: i64,
+    title: String,
+    body: Option<String>,
+    created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ProtectedNoteResponse {
+    note: NoteResponse,
+    subject: String,
+}
+
+#[derive(Debug, FromRow)]
+struct NoteRow {
+    id: i64,
+    title: String,
+    body: Option<String>,
+    created_at: String,
+}
+
+#[meld_server::dto]
+struct CreateNoteBody {
+    #[validate(length(min = 2, max = 120))]
+    title: String,
+    #[validate(length(max = 2000))]
+    body: Option<String>,
+}
+
+#[meld_server::dto]
+struct ListNotesQuery {
+    #[validate(range(min = 1, max = 100))]
+    limit: Option<i64>,
+}
+
+#[meld_server::dto]
+struct NotePath {
+    #[validate(range(min = 1))]
+    id: i64,
+}
+
+#[meld_server::route(get, "/livez")]
+async fn livez() -> Json<StatusResponse> {
+    Json(StatusResponse { status: "live" })
+}
+
+#[meld_server::route(get, "/health")]
+async fn health(State(state): State<Arc<ProductionApiState>>) -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok",
+        service: state.service_name.clone(),
+    })
+}
+
+#[meld_server::route(get, "/readyz")]
+async fn readyz(
+    State(state): State<Arc<ProductionApiState>>,
+) -> Result<Json<ReadyResponse>, ApiError> {
+    sqlx::query_scalar::<_, i32>("SELECT 1")
+        .fetch_one(&state.pool)
+        .await
+        .map_err(readiness_error)?;
+
+    Ok(Json(ReadyResponse {
+        status: "ready",
+        database: "ok",
+    }))
+}
+
+#[meld_server::route(post, "/v1/notes", auto_validate)]
+async fn create_note(
+    State(state): State<Arc<ProductionApiState>>,
+    Json(body): Json<CreateNoteBody>,
+) -> Result<(StatusCode, Json<NoteResponse>), ApiError> {
+    let note = sqlx::query_as::<_, NoteRow>(
+        r#"
+        INSERT INTO notes (title, body)
+        VALUES ($1, $2)
+        RETURNING
+            id,
+            title,
+            body,
+            to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS created_at
+        "#,
+    )
+    .bind(body.title)
+    .bind(body.body)
+    .fetch_one(&state.pool)
+    .await
+    .map_err(database_error)?;
+
+    Ok((StatusCode::CREATED, Json(note.into_response())))
+}
+
+#[meld_server::route(get, "/v1/notes", auto_validate)]
+async fn list_notes(
+    State(state): State<Arc<ProductionApiState>>,
+    axum::extract::Query(query): axum::extract::Query<ListNotesQuery>,
+) -> Result<Json<Vec<NoteResponse>>, ApiError> {
+    let limit = query.limit.unwrap_or(20);
+
+    let notes = sqlx::query_as::<_, NoteRow>(
+        r#"
+        SELECT
+            id,
+            title,
+            body,
+            to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS created_at
+        FROM notes
+        ORDER BY id DESC
+        LIMIT $1
+        "#,
+    )
+    .bind(limit)
+    .fetch_all(&state.pool)
+    .await
+    .map_err(database_error)?;
+
+    Ok(Json(
+        notes
+            .into_iter()
+            .map(NoteRow::into_response)
+            .collect::<Vec<_>>(),
+    ))
+}
+
+#[meld_server::route(get, "/protected/notes/:id", auto_validate)]
+async fn get_protected_note(
+    Extension(principal): Extension<AuthPrincipal>,
+    State(state): State<Arc<ProductionApiState>>,
+    axum::extract::Path(path): axum::extract::Path<NotePath>,
+) -> Result<Json<ProtectedNoteResponse>, ApiError> {
+    let maybe_note = sqlx::query_as::<_, NoteRow>(
+        r#"
+        SELECT
+            id,
+            title,
+            body,
+            to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS created_at
+        FROM notes
+        WHERE id = $1
+        "#,
+    )
+    .bind(path.id)
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(database_error)?;
+
+    let note = maybe_note.ok_or_else(|| not_found(format!("note {} was not found", path.id)))?;
+
+    Ok(Json(ProtectedNoteResponse {
+        note: note.into_response(),
+        subject: principal.subject,
+    }))
+}
+
+impl NoteRow {
+    fn into_response(self) -> NoteResponse {
+        NoteResponse {
+            id: self.id,
+            title: self.title,
+            body: self.body,
+            created_at: self.created_at,
+        }
+    }
+}
+
+fn not_found(message: String) -> ApiError {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ApiErrorResponse {
+            code: "not_found".to_string(),
+            message,
+            detail: None,
+            details: None,
+        }),
+    )
+}
+
+fn readiness_error(err: sqlx::Error) -> ApiError {
+    tracing::warn!(error = %err, "readiness check failed");
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(ApiErrorResponse {
+            code: "not_ready".to_string(),
+            message: "database is unavailable".to_string(),
+            detail: None,
+            details: None,
+        }),
+    )
+}
+
+fn database_error(err: sqlx::Error) -> ApiError {
+    tracing::error!(error = %err, "database operation failed");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ApiErrorResponse::internal_server_error()),
+    )
+}
+
+fn build_rest_router(state: Arc<ProductionApiState>, auth_cfg: AuthRuntimeConfig) -> Router {
+    let protected_router = Router::new()
+        .route("/protected/notes/:id", get(get_protected_note))
+        .route_layer(from_fn_with_state(auth_cfg, auth::rest_auth_middleware));
+
+    Router::new()
+        .route("/livez", get(livez))
+        .route("/health", get(health))
+        .route("/readyz", get(readyz))
+        .route("/v1/notes", get(list_notes).post(create_note))
+        .merge(protected_router)
+        .with_state(state)
+}
+
+fn spawn_migration_worker(pool: PgPool, retry_seconds: u64) {
+    tokio::spawn(async move {
+        let retry_interval = Duration::from_secs(retry_seconds.max(1));
+
+        loop {
+            match sqlx::migrate!("./migrations").run(&pool).await {
+                Ok(_) => {
+                    tracing::info!("database migrations are up to date");
+                    break;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        retry_seconds = retry_interval.as_secs(),
+                        "migration failed, retrying"
+                    );
+                    tokio::time::sleep(retry_interval).await;
+                }
+            }
+        }
+    });
+}
+
+fn init_tracing() {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,sqlx=warn,tower_http=info"));
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(true)
+        .try_init();
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    init_tracing();
+    let config = ProductionConfig::from_env()?;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(config.max_db_connections)
+        .connect_lazy(&config.database_url)?;
+
+    if config.run_migrations {
+        spawn_migration_worker(pool.clone(), config.migration_retry_seconds);
+    }
+
+    let rest_state = Arc::new(ProductionApiState::new(config.service_name.clone(), pool));
+    let rest_router = build_rest_router(rest_state, AuthRuntimeConfig::from_env());
+
+    let grpc_state = Arc::new(AppState::local(config.service_name.clone()));
+    MeldServer::new()
+        .with_addr(config.addr)
+        .with_state(grpc_state)
+        .with_rest_router(rest_router)
+        .on_startup(|addr| {
+            tracing::info!(addr = %addr, "production-api started");
+        })
+        .on_shutdown(|| {
+            tracing::info!("production-api shutting down");
+        })
+        .run()
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request};
+    use tower::util::ServiceExt;
+
+    #[test]
+    fn config_requires_database_url() {
+        let cfg = ProductionConfig::from_lookup(|key| match key {
+            "PROD_API_ADDR" => Some("127.0.0.1:4100".to_string()),
+            _ => None,
+        });
+        assert!(matches!(
+            cfg,
+            Err(ConfigError::MissingRequired {
+                key: "PROD_API_DATABASE_URL"
+            })
+        ));
+    }
+
+    #[test]
+    fn config_uses_defaults_when_optional_values_absent() {
+        let cfg = ProductionConfig::from_lookup(|key| {
+            if key == "PROD_API_DATABASE_URL" {
+                Some("postgres://postgres:postgres@127.0.0.1:55432/meld".to_string())
+            } else {
+                None
+            }
+        })
+        .expect("config should parse");
+
+        assert_eq!(cfg.addr, SocketAddr::from(([127, 0, 0, 1], 4100)));
+        assert_eq!(cfg.service_name, "production-api");
+        assert_eq!(cfg.max_db_connections, 10);
+        assert!(cfg.run_migrations);
+        assert_eq!(cfg.migration_retry_seconds, 5);
+    }
+
+    #[tokio::test]
+    async fn readyz_returns_503_when_database_is_unavailable() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://postgres:postgres@127.0.0.1:1/meld")
+            .expect("lazy pool should build");
+
+        let state = Arc::new(ProductionApiState::new(
+            "test-production-api".to_string(),
+            pool,
+        ));
+        let app = build_rest_router(state, AuthRuntimeConfig::default());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/readyz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -4,28 +4,31 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-echo "[1/9] cargo fmt --all -- --check"
+echo "[1/10] cargo fmt --all -- --check"
 cargo fmt --all -- --check
 
-echo "[2/9] cargo clippy --workspace --all-targets -- -D warnings"
+echo "[2/10] cargo clippy --workspace --all-targets -- -D warnings"
 cargo clippy --workspace --all-targets -- -D warnings
 
-echo "[3/9] cargo check --workspace"
+echo "[3/10] cargo check --workspace"
 cargo check --workspace
 
-echo "[4/9] cargo test --workspace"
+echo "[4/10] cargo test --workspace"
 cargo test --workspace
 
-echo "[5/9] cargo test -p meld-server --test multiplexing -- --nocapture"
+echo "[5/10] cargo test -p production-api -- --nocapture"
+cargo test -p production-api -- --nocapture
+
+echo "[6/10] cargo test -p meld-server --test multiplexing -- --nocapture"
 cargo test -p meld-server --test multiplexing -- --nocapture
 
-echo "[6/9] scripts/check_contracts_bundle.sh"
+echo "[7/10] scripts/check_contracts_bundle.sh"
 ./scripts/check_contracts_bundle.sh
 
-echo "[7/9] cargo test -p meld-server openapi_json_is_available -- --nocapture"
+echo "[8/10] cargo test -p meld-server openapi_json_is_available -- --nocapture"
 cargo test -p meld-server openapi_json_is_available -- --nocapture
 
-echo "[8/9] scripts/prod_preflight.sh"
+echo "[9/10] scripts/prod_preflight.sh"
 MELD_PREFLIGHT_SECURE=true \
 MELD_PREFLIGHT_BOOT_SERVER=true \
 MELD_PREFLIGHT_WAIT_SECONDS=120 \
@@ -40,7 +43,7 @@ MELD_REQUEST_BODY_LIMIT_BYTES=1048576 \
 MELD_MAX_IN_FLIGHT_REQUESTS=1024 \
 ./scripts/prod_preflight.sh
 
-echo "[9/9] scripts/release_dry_run.sh"
+echo "[10/10] scripts/release_dry_run.sh"
 ./scripts/release_dry_run.sh
 
 if cargo audit -V >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add a new production-oriented reference example at `examples/production-api`
- implement explicit env config parsing/validation, DB-backed REST endpoints, and auth-protected REST routes
- add liveness/health/readiness probes, migration retry worker, startup/shutdown hooks, and tracing bootstrap
- add local PostgreSQL asset (`docker-compose.yml`) + SQL migration (`migrations/0001_create_notes.sql`)
- add docs/runbook updates and explicit CI/local CI checks for the new example

## Implementation Details
- new crate: `production-api` (workspace member)
- required env: `PROD_API_DATABASE_URL`
- optional env with defaults:
  - `PROD_API_ADDR=127.0.0.1:4100`
  - `PROD_API_SERVICE_NAME=production-api`
  - `PROD_API_DB_MAX_CONNECTIONS=10`
  - `PROD_API_RUN_MIGRATIONS=true`
  - `PROD_API_MIGRATION_RETRY_SECONDS=5`
- REST routes:
  - `GET /livez`
  - `GET /health`
  - `GET /readyz`
  - `POST /v1/notes` (DB-backed)
  - `GET /v1/notes` (DB-backed)
  - `GET /protected/notes/:id` (auth middleware + principal extraction)
- gRPC call path remains available on the same port through `MeldServer` default gRPC routes

## Docs
- `examples/production-api/README.md` quickstart + auth/gRPC smoke flow + troubleshooting
- `docs/production/production-api-runbook.md` local boot, migration behavior, smoke tests, and failure recovery
- root README and CI workflow docs updated

## Validation
- `cargo fmt --all`
- `cargo test -p production-api -- --nocapture`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p meld-server --test multiplexing -- --nocapture`
- `./scripts/check_contracts_bundle.sh`

Closes #60
