### PR TITLE
feat(test): add nextest/coverage CI and property test suite (#61)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,62 @@ jobs:
       - name: Production example tests
         run: cargo test -p production-api -- --nocapture
 
+  nextest:
+    name: Nextest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Run nextest workspace suite
+        run: cargo nextest run --workspace --all-targets
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Add LLVM tools preview
+        run: rustup component add llvm-tools-preview
+
+      - name: Generate coverage artifacts
+        run: |
+          mkdir -p target/coverage
+          cargo llvm-cov --workspace --summary-only | tee target/coverage/summary.txt
+          cargo llvm-cov --workspace --lcov --output-path target/coverage/lcov.info
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            target/coverage/summary.txt
+            target/coverage/lcov.info
+
   rest-grpc-e2e:
     name: REST gRPC E2E
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1420,7 @@ dependencies = [
  "meld-core",
  "meld-macros",
  "meld-rpc",
+ "proptest",
  "pulldown-cmark",
  "reqwest",
  "serde",
@@ -1768,6 +1784,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,6 +1938,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2070,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2262,6 +2312,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3191,6 +3253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,6 +3433,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ utoipa-swagger-ui = { version = "8", features = ["axum"] }
 http = "1"
 validator = { version = "0.19", features = ["derive"] }
 pulldown-cmark = "0.13"
+proptest = "1"

--- a/README.md
+++ b/README.md
@@ -219,6 +219,14 @@ This runs:
 - OpenAPI route check
 - production preflight gate
 
+Extended testing quality gate (nextest + coverage):
+
+```bash
+./scripts/test_quality.sh
+```
+
+See `docs/testing-toolchain.md` for setup and coverage artifacts.
+
 ## Production Readiness Docs
 
 - `docs/production/deployment.md`

--- a/crates/meld-server/Cargo.toml
+++ b/crates/meld-server/Cargo.toml
@@ -37,3 +37,4 @@ pulldown-cmark.workspace = true
 jsonwebtoken.workspace = true
 reqwest.workspace = true
 tokio-tungstenite.workspace = true
+proptest.workspace = true

--- a/crates/meld-server/tests/property_api.rs
+++ b/crates/meld-server/tests/property_api.rs
@@ -1,0 +1,75 @@
+use axum::{http::StatusCode, Json};
+use meld_core::MeldError;
+use meld_server::api::{
+    map_domain_error_to_grpc, map_domain_error_to_rest, validation_error_with_source,
+};
+use proptest::prelude::*;
+use validator::Validate;
+
+#[derive(Debug, Clone, Validate)]
+struct BoundaryDto {
+    #[validate(length(min = 3, max = 12))]
+    name: String,
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        failure_persistence: None,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn validation_error_shape_is_stable_for_invalid_dto(input in "\\PC{0,2}") {
+        let dto = BoundaryDto { name: input };
+        let err = dto.validate().expect_err("expected boundary validation error");
+        let (status, Json(body)) = validation_error_with_source(err, "body");
+
+        prop_assert_eq!(status, StatusCode::BAD_REQUEST);
+        prop_assert_eq!(body.code, "validation_error");
+
+        let detail = body.detail.expect("validation detail should exist");
+        prop_assert!(!detail.is_empty());
+
+        for issue in detail {
+            prop_assert_eq!(issue.loc.first().map(String::as_str), Some("body"));
+            prop_assert_eq!(issue.loc.get(1).map(String::as_str), Some("name"));
+            prop_assert!(!issue.msg.is_empty());
+            prop_assert!(!issue.issue_type.is_empty());
+        }
+    }
+
+    #[test]
+    fn internal_error_mapping_is_sanitized(message in "(?s).{1,64}") {
+        let (status, Json(rest)) = map_domain_error_to_rest(MeldError::Internal(message.clone()));
+        prop_assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        prop_assert_eq!(rest.code, "internal_error");
+        prop_assert_eq!(rest.message.as_str(), "internal server error");
+        prop_assert!(!rest.message.contains(&message));
+
+        let grpc = map_domain_error_to_grpc(MeldError::Internal(message));
+        prop_assert_eq!(grpc.code(), tonic::Code::Internal);
+        prop_assert_eq!(grpc.message(), "internal server error");
+    }
+
+    #[test]
+    fn dto_length_boundary_matches_contract(input in "\\PC{0,16}") {
+        let dto = BoundaryDto {
+            name: input.clone(),
+        };
+        let is_valid = dto.validate().is_ok();
+        let len = input.chars().count();
+
+        prop_assert_eq!(is_valid, (3..=12).contains(&len));
+    }
+
+    #[test]
+    fn validation_domain_error_mapping_preserves_bad_request(message in "(?s).{1,64}") {
+        let (status, Json(rest)) = map_domain_error_to_rest(MeldError::Validation(message.clone()));
+        prop_assert_eq!(status, StatusCode::BAD_REQUEST);
+        prop_assert_eq!(rest.code, "validation_error");
+        prop_assert!(!rest.message.is_empty());
+
+        let grpc = map_domain_error_to_grpc(MeldError::Validation(message));
+        prop_assert_eq!(grpc.code(), tonic::Code::InvalidArgument);
+    }
+}

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -7,20 +7,28 @@ This project uses focused CI jobs so failures are clearly scoped:
 - `cargo test --workspace`
 - `cargo test -p production-api -- --nocapture`
 
-2. `REST gRPC E2E`
+2. `Nextest`
+- `cargo nextest run --workspace --all-targets`
+
+3. `Coverage`
+- `cargo llvm-cov --workspace --summary-only`
+- `cargo llvm-cov --workspace --lcov --output-path target/coverage/lcov.info`
+- uploads `coverage-report` artifact (summary + lcov)
+
+4. `REST gRPC E2E`
 - `cargo test -p meld-server --test multiplexing -- --nocapture`
 
-3. `Docs Contract Drift Check`
+5. `Docs Contract Drift Check`
 - `./scripts/check_contracts_bundle.sh`
 - `cargo test -p meld-server openapi_json_is_available -- --nocapture`
 
-4. `Security Audit`
+6. `Security Audit`
 - `cargo audit`
 
-5. `Production Preflight`
+7. `Production Preflight`
 - `./scripts/prod_preflight.sh` with secure-mode CI environment
 
-6. `Release Dry Run`
+8. `Release Dry Run`
 - `./scripts/release_dry_run.sh`
 
 ## Local Equivalent
@@ -32,3 +40,11 @@ Run:
 ```
 
 This runs the same command set as CI in a single local flow.
+
+For dedicated nextest + coverage quality gates, run:
+
+```bash
+./scripts/test_quality.sh
+```
+
+See `docs/testing-toolchain.md` for installation and outputs.

--- a/docs/testing-toolchain.md
+++ b/docs/testing-toolchain.md
@@ -1,0 +1,46 @@
+# Testing Toolchain
+
+This project uses an extended test toolchain for faster execution and measurable reliability:
+
+- `cargo nextest` for stable and parallel test execution
+- `cargo llvm-cov` for workspace coverage reports
+- property tests (`proptest`) for API invariants
+
+## Install Tools
+
+```bash
+cargo install cargo-nextest --locked
+cargo install cargo-llvm-cov --locked
+rustup component add llvm-tools-preview
+```
+
+## Run Local Quality Gate
+
+```bash
+./scripts/test_quality.sh
+```
+
+Expected outputs:
+
+- `target/coverage/summary.txt`
+- `target/coverage/lcov.info`
+
+## Run Individual Commands
+
+```bash
+cargo nextest run --workspace --all-targets
+cargo llvm-cov --workspace --summary-only
+cargo llvm-cov --workspace --lcov --output-path target/coverage/lcov.info
+```
+
+## Property Tests
+
+Property-based API invariants are in:
+
+- `crates/meld-server/tests/property_api.rs`
+
+They validate:
+
+- validation error shape stability
+- REST/gRPC domain error mapping invariants
+- DTO boundary behavior

--- a/scripts/test_quality.sh
+++ b/scripts/test_quality.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+require_tool() {
+  local subcommand="$1"
+  if ! cargo "$subcommand" --version >/dev/null 2>&1; then
+    echo "[FAIL] cargo-$subcommand is not installed"
+    echo "Install: cargo install cargo-$subcommand --locked"
+    exit 1
+  fi
+}
+
+require_tool "nextest"
+require_tool "llvm-cov"
+
+mkdir -p target/coverage
+
+echo "[1/3] cargo nextest run --workspace --all-targets"
+cargo nextest run --workspace --all-targets
+
+echo "[2/3] cargo llvm-cov --workspace --summary-only"
+cargo llvm-cov --workspace --summary-only | tee target/coverage/summary.txt
+
+echo "[3/3] cargo llvm-cov --workspace --lcov --output-path target/coverage/lcov.info"
+cargo llvm-cov --workspace --lcov --output-path target/coverage/lcov.info
+
+echo "Quality checks completed."
+echo "Coverage summary: target/coverage/summary.txt"
+echo "Coverage lcov: target/coverage/lcov.info"


### PR DESCRIPTION
## Summary
- add explicit CI jobs for `cargo-nextest` and `cargo-llvm-cov`
- generate and upload coverage artifacts (`summary.txt`, `lcov.info`) in CI
- add property-based API invariant tests in `meld-server`
- add a dedicated local quality command for nextest + coverage
- document installation and usage for contributors

## What Changed

### CI integration
- `.github/workflows/ci.yml`
  - new `Nextest` job running: `cargo nextest run --workspace --all-targets`
  - new `Coverage` job running:
    - `cargo llvm-cov --workspace --summary-only`
    - `cargo llvm-cov --workspace --lcov --output-path target/coverage/lcov.info`
  - uploads coverage artifact: `coverage-report`

### Property tests
- `crates/meld-server/tests/property_api.rs`
  - validation error shape stability (`validation_error_with_source`)
  - internal domain error mapping sanitization invariants (REST/gRPC)
  - DTO boundary invariants (length min/max)
  - validation domain error mapping behavior

### Local quality workflow
- `scripts/test_quality.sh`
  - runs nextest and coverage generation in one command
  - writes outputs to:
    - `target/coverage/summary.txt`
    - `target/coverage/lcov.info`

### Documentation
- `docs/testing-toolchain.md` (new)
- `docs/ci-workflow.md` updated with Nextest/Coverage jobs and local quality command
- `README.md` updated with the extended quality gate command

## Validation
- `cargo fmt --all`
- `cargo test -p meld-server --test property_api -- --nocapture`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #61
