### PR TITLE
feat(multiplexing): add explicit dual-port REST+gRPC mode (#68)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,22 @@ Notes:
 - `configure_tonic(...)` is route-level customization over `tonic::service::Routes`; it is not a full `tonic::transport::Server` builder replacement.
 - If `without_grpc()` is set, `configure_tonic(...)` is a no-op.
 
+### Dual-Port Mode
+
+Single-port remains the default, but you can split listeners explicitly:
+
+```rust
+use openportio_server::OpenportioServer;
+
+OpenportioServer::new()
+    .with_rest_addr(([0, 0, 0, 0], 3000).into())
+    .with_grpc_addr(([0, 0, 0, 0], 50051).into())
+    .run()
+    .await?;
+```
+
+Use this when infrastructure policy requires explicit REST/gRPC port separation.
+
 See:
 - `docs/fastapi-like-builder.md`
 - `docs/dx-scorecard.md`

--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -301,6 +301,32 @@ Test override helper:
 - Default `OpenportioServer::new()` enables both REST and gRPC on a single listener.
 - Default address uses `OPENPORTIO_SERVER_ADDR` if set, otherwise `127.0.0.1:3000`.
 
+## Single-Port vs Dual-Port
+
+Default mode is single-port multiplexing:
+
+```rust
+OpenportioServer::new()
+    .with_addr(([0, 0, 0, 0], 3000).into())
+    .run()
+    .await?;
+```
+
+Explicit dual-port mode:
+
+```rust
+OpenportioServer::new()
+    .with_rest_addr(([0, 0, 0, 0], 3000).into())
+    .with_grpc_addr(([0, 0, 0, 0], 50051).into())
+    .run()
+    .await?;
+```
+
+Operational guidance:
+- Keep single-port for local development and simple edge deployments.
+- Use dual-port when platform networking prefers explicit protocol separation (for example dedicated gRPC service ports, strict L4/L7 rules, or separate SLO tracking).
+- Dual-port config is all-or-nothing: both `with_rest_addr(...)` and `with_grpc_addr(...)` must be provided.
+
 ## gRPC Quickstart (No-Auth + Auth)
 
 Prerequisites:

--- a/docs/production/deployment.md
+++ b/docs/production/deployment.md
@@ -33,6 +33,33 @@ OPENPORTIO_CORS_ALLOW_ORIGINS=https://app.example.com \
 cargo run -p openportio-server
 ```
 
+## Single-Port vs Dual-Port Deployment
+
+Single-port (default) runs REST + gRPC on one listener:
+- simpler ingress and fewer exposed ports
+- good default for most teams
+
+Dual-port mode splits REST and gRPC listeners:
+- useful when your platform/load-balancer expects separate protocol ports
+- enables independent traffic policy and SLO management per protocol
+
+Programmatic dual-port example:
+
+```rust
+use openportio_server::OpenportioServer;
+
+OpenportioServer::new()
+    .with_rest_addr(([0, 0, 0, 0], 3000).into())
+    .with_grpc_addr(([0, 0, 0, 0], 50051).into())
+    .run()
+    .await?;
+```
+
+Migration guidance:
+- start from your existing single-port config
+- introduce a dedicated gRPC port and route gRPC traffic there first
+- keep REST on current port, validate probes/alerts, then remove single-port assumptions from infrastructure
+
 ## Preflight Gate (Recommended Before Rollout)
 
 ```bash


### PR DESCRIPTION
## Summary
- Add explicit dual-port server mode with builder APIs:
  - `with_rest_addr(...)`
  - `with_grpc_addr(...)`
- Keep single-port multiplexing as the default mode (`with_addr(...)` / default addr).
- Add startup/runtime validation for dual-port mode:
  - dual-port requires both REST and gRPC addresses
  - dual-port rejects `without_grpc()` combinations
- Implement dual listener runtime lifecycle with coordinated graceful shutdown.

## Runtime Behavior
- Single-port mode (default): unchanged, one listener serves merged REST+gRPC router.
- Dual-port mode: two listeners run concurrently:
  - REST listener serves REST/raw merged router
  - gRPC listener serves tonic routes
- Startup hooks fire once per active listener address in dual-port mode.
- Shutdown hooks fire once after both listeners terminate.

## Tests
- Added builder test: dual-port requires both addresses.
- Added integration test: `serves_rest_and_grpc_on_explicit_dual_ports`.
- Existing single-port integration test remains green.

## Docs
- README dual-port usage snippet and guidance.
- `docs/fastapi-like-builder.md` single-port vs dual-port section.
- `docs/production/deployment.md` operational tradeoffs + migration guidance.

## Validation
- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test -p openportio-server --test multiplexing`
- `cargo test -p openportio-server`
- `cargo clippy -p openportio-server --all-targets -- -D warnings`

Closes #68
