### PR TITLE
feat(framework): composable DTO derives + trait-first validation (#69)

### DIFF
--- a/crates/openportio-server/README.md
+++ b/crates/openportio-server/README.md
@@ -7,3 +7,4 @@ Includes:
 - middleware stack (timeouts, request-id, CORS, limits, tracing)
 - OpenAPI and gRPC contract discovery endpoints
 - FastAPI-like builder and extractor ergonomics
+- DTO options: `#[dto]`, composable derive aliases, trait-first `RequestValidation`

--- a/crates/openportio-server/src/lib.rs
+++ b/crates/openportio-server/src/lib.rs
@@ -49,13 +49,20 @@ pub use builder::OpenportioServer;
 pub use openportio_macros::{dto, route};
 pub use serde;
 pub use utoipa;
+pub use utoipa::ToSchema as MeldSchema;
+pub use utoipa::ToSchema as OpenPortIOSchema;
+pub use utoipa::ToSchema as OpenportioSchema;
 pub use validator;
+pub use validator::Validate as MeldValidate;
+pub use validator::Validate as OpenPortIOValidate;
+pub use validator::Validate as OpenportioValidate;
 pub type MeldServer = OpenportioServer;
 pub type AlloyServer = OpenportioServer;
 
 pub mod prelude {
     pub use crate::api::{
-        ApiError, ApiErrorResponse, ValidatedJson, ValidatedParts, ValidatedPath, ValidatedQuery,
+        ApiError, ApiErrorResponse, RequestValidation, ValidatedJson, ValidatedParts,
+        ValidatedPath, ValidatedQuery,
     };
     pub use crate::di::{
         with_dependency, with_dependency_override, with_dependency_overrides, DependencyOverrides,
@@ -64,7 +71,10 @@ pub mod prelude {
     pub use crate::AlloyServer;
     pub use crate::MeldServer;
     pub use crate::OpenportioServer;
-    pub use crate::{dto, route};
+    pub use crate::{
+        dto, route, MeldSchema, MeldValidate, OpenPortIOSchema, OpenPortIOValidate,
+        OpenportioSchema, OpenportioValidate,
+    };
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]

--- a/crates/openportio-server/tests/dto_modes.rs
+++ b/crates/openportio-server/tests/dto_modes.rs
@@ -1,0 +1,124 @@
+use axum::Json;
+use openportio_server::api::RequestValidation;
+use openportio_server::utoipa::OpenApi;
+use serde_json::Value;
+
+#[openportio_server::dto]
+struct LegacyDto {
+    #[validate(length(min = 2, max = 120))]
+    title: String,
+}
+
+#[derive(
+    openportio_server::serde::Deserialize,
+    openportio_server::OpenPortIOValidate,
+    openportio_server::OpenPortIOSchema,
+)]
+struct ComposableDto {
+    #[validate(length(min = 2, max = 120))]
+    title: String,
+}
+
+#[derive(
+    openportio_server::serde::Deserialize,
+    openportio_server::MeldValidate,
+    openportio_server::MeldSchema,
+)]
+struct MeldAliasDto {
+    #[validate(length(min = 2, max = 120))]
+    title: String,
+}
+
+#[derive(OpenApi)]
+#[openapi(components(schemas(LegacyDto, ComposableDto, MeldAliasDto)))]
+struct DtoModesApiDoc;
+
+#[test]
+fn dto_macro_and_composable_derives_match_validation_contract() {
+    let legacy = LegacyDto {
+        title: "x".to_string(),
+    };
+    let composable = ComposableDto {
+        title: "x".to_string(),
+    };
+    let meld_alias = MeldAliasDto {
+        title: "x".to_string(),
+    };
+
+    let (legacy_status, Json(legacy_body)) = legacy
+        .validate_request("body")
+        .expect_err("legacy dto should fail validation");
+    let (composable_status, Json(composable_body)) = composable
+        .validate_request("body")
+        .expect_err("composable dto should fail validation");
+    let (meld_alias_status, Json(meld_alias_body)) = meld_alias
+        .validate_request("body")
+        .expect_err("meld alias dto should fail validation");
+
+    assert_eq!(legacy_status, composable_status);
+    assert_eq!(legacy_status, meld_alias_status);
+    assert_eq!(legacy_body.code, composable_body.code);
+    assert_eq!(legacy_body.code, meld_alias_body.code);
+    assert_eq!(legacy_body.message, composable_body.message);
+    assert_eq!(legacy_body.message, meld_alias_body.message);
+
+    let legacy_detail = legacy_body.detail.expect("legacy detail");
+    let composable_detail = composable_body.detail.expect("composable detail");
+    let meld_alias_detail = meld_alias_body.detail.expect("meld alias detail");
+    assert_eq!(legacy_detail.len(), composable_detail.len());
+    assert_eq!(legacy_detail.len(), meld_alias_detail.len());
+    assert_eq!(legacy_detail[0].loc, composable_detail[0].loc);
+    assert_eq!(legacy_detail[0].loc, meld_alias_detail[0].loc);
+}
+
+#[test]
+fn dto_macro_and_composable_derives_match_schema_shape() {
+    let components = DtoModesApiDoc::openapi()
+        .components
+        .expect("components should be generated");
+    let mut legacy_schema = serde_json::to_value(
+        components
+            .schemas
+            .get("LegacyDto")
+            .expect("legacy schema should exist"),
+    )
+    .expect("legacy schema value");
+    let mut composable_schema = serde_json::to_value(
+        components
+            .schemas
+            .get("ComposableDto")
+            .expect("composable schema should exist"),
+    )
+    .expect("composable schema value");
+    let mut meld_alias_schema = serde_json::to_value(
+        components
+            .schemas
+            .get("MeldAliasDto")
+            .expect("meld alias schema should exist"),
+    )
+    .expect("meld alias schema value");
+
+    strip_titles(&mut legacy_schema);
+    strip_titles(&mut composable_schema);
+    strip_titles(&mut meld_alias_schema);
+
+    assert_eq!(legacy_schema, composable_schema);
+    assert_eq!(legacy_schema, meld_alias_schema);
+}
+
+fn strip_titles(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            map.remove("title");
+            for nested in map.values_mut() {
+                strip_titles(nested);
+            }
+        }
+        Value::Array(items) => {
+            for nested in items {
+                strip_titles(nested);
+            }
+        }
+        _ => {}
+    }
+}

--- a/docs/dx-scorecard.md
+++ b/docs/dx-scorecard.md
@@ -77,3 +77,26 @@ REST and gRPC now share one domain-error mapping policy:
 Result:
 - Safer external error surface
 - Better observability without leaking internals
+
+## 6) Composable DTO + Trait-First Escape Hatch
+
+Openportio now supports explicit DTO composition without the all-in-one macro:
+
+```rust
+#[derive(
+    openportio_server::serde::Deserialize,
+    openportio_server::OpenPortIOValidate,
+    openportio_server::OpenPortIOSchema
+)]
+struct CreateNoteBody {
+    #[validate(length(min = 2, max = 120))]
+    title: String,
+}
+```
+
+For advanced validation logic that cannot be expressed with `validator` attributes, DTOs can implement:
+- `openportio_server::api::RequestValidation`
+
+Result:
+- All-in-one convenience (`#[dto]`) remains intact
+- Advanced teams get trait-first control without abandoning Openportio extractors


### PR DESCRIPTION
## Summary
- add composable DTO derive aliases at the framework root:
  - `OpenPortIOValidate` / `OpenPortIOSchema`
  - compatibility aliases: `MeldValidate` / `MeldSchema`
- add trait-first validation escape hatch via `openportio_server::api::RequestValidation`
- update `ValidatedJson` / `ValidatedQuery` / `ValidatedPath` / `ValidatedParts` to use `RequestValidation`
- keep `#[openportio_server::dto]` behavior backward-compatible for existing users
- document side-by-side migration paths (`#[dto]` vs composable derives vs trait-first)
- add equivalence tests for validation + schema generation paths

## Why
Implements issue #69 to break the "all-in-one DTO macro only" constraint by providing composable derive ergonomics plus a trait-first escape hatch for advanced logic.

## Validation
- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test -p openportio-server`
- `cargo test -p openportio-macros`
- `cargo clippy -p openportio-server --all-targets -- -D warnings`

Closes #69
