### PR TITLE
chore(docs): harden docs-site operations and deploy checks (#77)

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -46,11 +46,35 @@ jobs:
         working-directory: website
         run: npm ci
 
+      - name: Check docs links
+        working-directory: website
+        run: npm run docs:check-links
+
       - name: Build docs site
         working-directory: website
         env:
           VITEPRESS_BASE: /Openportio/
+          VITEPRESS_SITE_ORIGIN: https://jaeyoung0509.github.io
         run: npm run docs:build
+
+      - name: Verify sitemap and robots outputs
+        run: |
+          set -euo pipefail
+          test -f website/docs/.vitepress/dist/sitemap.xml || {
+            echo "::error::missing website/docs/.vitepress/dist/sitemap.xml";
+            exit 1;
+          }
+          test -f website/docs/.vitepress/dist/robots.txt || {
+            echo "::error::missing website/docs/.vitepress/dist/robots.txt";
+            exit 1;
+          }
+          expected_sitemap="https://jaeyoung0509.github.io/Openportio/sitemap.xml"
+          if ! grep -q "${expected_sitemap}" website/docs/.vitepress/dist/robots.txt; then
+            echo "::error::robots.txt does not include expected sitemap URL: ${expected_sitemap}"
+            echo "robots.txt content:"
+            cat website/docs/.vitepress/dist/robots.txt
+            exit 1
+          fi
 
       - name: Upload docs artifact (PR)
         if: github.event_name == 'pull_request'
@@ -78,6 +102,16 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Post-deploy smoke check
+        env:
+          DOCS_URL: ${{ steps.deployment.outputs.page_url }}
+        run: |
+          set -euo pipefail
+          ./scripts/check_docs_site_smoke.sh "${DOCS_URL}" "Openportio"

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -37,6 +37,10 @@ This project uses focused CI jobs so failures are clearly scoped:
 - runs REST (`k6`) + gRPC (`ghz`) perf smoke with threshold enforcement
 - uploads artifact: `perf-report`
 
+10. `Docs Site`
+- workflow: `.github/workflows/docs-site.yml`
+- validates docs links, builds VitePress, verifies `sitemap.xml` + `robots.txt`, deploys GitHub Pages, then runs post-deploy smoke check
+
 ## Local Equivalent
 
 Run:
@@ -62,3 +66,9 @@ For local perf regression gate, run:
 ```
 
 See `docs/performance-gates.md` for thresholds and tuning guidance.
+
+For docs-site failure triage and rollback/retry, see:
+
+```bash
+docs/release/docs-site-runbook.md
+```

--- a/docs/release/docs-site-runbook.md
+++ b/docs/release/docs-site-runbook.md
@@ -1,0 +1,70 @@
+# Docs Site Ops Runbook
+
+This runbook covers incident response for the VitePress docs pipeline in `.github/workflows/docs-site.yml`.
+
+## Pipeline Gates
+
+`Docs Site` workflow enforces:
+- docs markdown internal link validation (`npm run docs:check-links`)
+- static site build (`npm run docs:build`)
+- generated output checks:
+  - `website/docs/.vitepress/dist/sitemap.xml`
+  - `website/docs/.vitepress/dist/robots.txt`
+  - expected sitemap URL in `robots.txt`
+- post-deploy smoke check via `./scripts/check_docs_site_smoke.sh`
+
+## Local Reproduction
+
+From repository root:
+
+```bash
+cd website
+npm ci
+npm run docs:check-links
+VITEPRESS_BASE=/Openportio/ \
+VITEPRESS_SITE_ORIGIN=https://jaeyoung0509.github.io \
+npm run docs:build
+```
+
+Validate generated artifacts:
+
+```bash
+test -f website/docs/.vitepress/dist/sitemap.xml
+test -f website/docs/.vitepress/dist/robots.txt
+cat website/docs/.vitepress/dist/robots.txt
+```
+
+Optional local smoke check:
+
+```bash
+cd website
+VITEPRESS_BASE=/Openportio/ npm run docs:preview -- --host 127.0.0.1 --port 4173
+```
+
+In another shell:
+
+```bash
+./scripts/check_docs_site_smoke.sh http://127.0.0.1:4173/Openportio/ Openportio
+```
+
+## Failure Triage
+
+- `docs:check-links` failed
+  - fix missing/renamed docs links in `website/docs/**/*.md`
+  - rerun `npm run docs:check-links`
+- missing `sitemap.xml` / `robots.txt`
+  - rerun build with expected env (`VITEPRESS_BASE`, `VITEPRESS_SITE_ORIGIN`)
+  - confirm `website/scripts/generate-robots.mjs` runs in build
+- smoke check failed after deploy
+  - inspect workflow step logs for headers/body snippet
+  - manually `curl -iL <page_url>` to confirm status and marker text
+  - if GitHub Pages propagation delay is suspected, rerun failed workflow
+
+## Rollback / Retry
+
+1. Identify last known-good docs commit on `develop`/`main`.
+2. Revert problematic docs-site commit(s) in a PR targeting `develop`.
+3. Merge revert PR and confirm `Docs Site` workflow is green.
+4. If only deployment flaked (content is correct), use Actions "Re-run failed jobs".
+5. Verify production URL after recovery:
+   - `https://jaeyoung0509.github.io/Openportio/`

--- a/scripts/check_docs_site_smoke.sh
+++ b/scripts/check_docs_site_smoke.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCS_URL="${1:-}"
+EXPECTED_MARKER="${2:-Openportio}"
+MAX_ATTEMPTS="${3:-10}"
+SLEEP_SECONDS="${4:-5}"
+
+if [[ -z "${DOCS_URL}" ]]; then
+  echo "[ERROR] usage: $0 <docs-url> [expected-marker] [max-attempts] [sleep-seconds]"
+  exit 2
+fi
+
+TMP_HEADERS="$(mktemp)"
+TMP_BODY="$(mktemp)"
+
+cleanup() {
+  rm -f "${TMP_HEADERS}" "${TMP_BODY}"
+}
+trap cleanup EXIT
+
+echo "[INFO] docs smoke check"
+echo "[INFO] url=${DOCS_URL}"
+echo "[INFO] expected_marker=${EXPECTED_MARKER}"
+echo "[INFO] attempts=${MAX_ATTEMPTS} sleep=${SLEEP_SECONDS}s"
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  HTTP_CODE="$(
+    curl -sS -L \
+      -D "${TMP_HEADERS}" \
+      -o "${TMP_BODY}" \
+      -w "%{http_code}" \
+      "${DOCS_URL}" || true
+  )"
+
+  if [[ "${HTTP_CODE}" == "200" ]] && grep -q "${EXPECTED_MARKER}" "${TMP_BODY}"; then
+    echo "[OK] docs smoke passed on attempt ${attempt}"
+    exit 0
+  fi
+
+  echo "[WARN] attempt ${attempt}/${MAX_ATTEMPTS} failed (status=${HTTP_CODE})"
+  echo "[WARN] response headers (first 20 lines):"
+  sed -n '1,20p' "${TMP_HEADERS}" || true
+  echo "[WARN] response body snippet (first 40 lines):"
+  sed -n '1,40p' "${TMP_BODY}" || true
+
+  if (( attempt < MAX_ATTEMPTS )); then
+    sleep "${SLEEP_SECONDS}"
+  fi
+done
+
+echo "[ERROR] docs smoke check failed after ${MAX_ATTEMPTS} attempts"
+exit 1

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 docs/.vitepress/cache/
 docs/.vitepress/dist/
+docs/public/robots.txt

--- a/website/README.md
+++ b/website/README.md
@@ -17,11 +17,19 @@ cd website
 npm run docs:build
 ```
 
+## Validate Links
+
+```bash
+cd website
+npm run docs:check-links
+```
+
 ## GitHub Pages Deploy
 
 CI builds and deploys this site via GitHub Actions on pushes to `develop`/`main`.
-Production base path is set with:
+Production env defaults:
 
 ```bash
 VITEPRESS_BASE=/Openportio/
+VITEPRESS_SITE_ORIGIN=https://jaeyoung0509.github.io
 ```

--- a/website/docs/.vitepress/config.mts
+++ b/website/docs/.vitepress/config.mts
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vitepress';
 
 const base = process.env.VITEPRESS_BASE || '/';
+const siteOrigin = (process.env.VITEPRESS_SITE_ORIGIN || 'https://jaeyoung0509.github.io').replace(
+  /\/$/,
+  ''
+);
+const basePath = base === '/' ? '' : base.replace(/\/$/, '');
 
 export default defineConfig({
   base,
@@ -9,6 +14,9 @@ export default defineConfig({
   cleanUrls: true,
   lastUpdated: true,
   lang: 'en-US',
+  sitemap: {
+    hostname: `${siteOrigin}${basePath}`
+  },
   themeConfig: {
     logo: '/openportio-logo.svg',
     siteTitle: 'Openportio Docs',

--- a/website/package.json
+++ b/website/package.json
@@ -4,8 +4,10 @@
   "version": "0.1.0",
   "description": "VitePress documentation site for Openportio",
   "scripts": {
-    "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
+    "docs:prepare": "node ./scripts/generate-robots.mjs",
+    "docs:check-links": "node ./scripts/check-links.mjs",
+    "docs:dev": "npm run docs:prepare && vitepress dev docs",
+    "docs:build": "npm run docs:prepare && vitepress build docs && node ./scripts/fix-sitemap.mjs",
     "docs:preview": "vitepress preview docs"
   },
   "devDependencies": {

--- a/website/scripts/check-links.mjs
+++ b/website/scripts/check-links.mjs
@@ -1,0 +1,153 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const docsRoot = path.resolve(__dirname, '..', 'docs');
+
+function collectMarkdownFiles(dir) {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '.vitepress') {
+        continue;
+      }
+      files.push(...collectMarkdownFiles(fullPath));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function normalizeLinkTarget(rawTarget) {
+  const trimmed = rawTarget.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const unwrapped =
+    trimmed.startsWith('<') && trimmed.endsWith('>')
+      ? trimmed.slice(1, -1).trim()
+      : trimmed.split(/\s+/)[0];
+
+  if (
+    unwrapped.startsWith('#') ||
+    unwrapped.startsWith('http://') ||
+    unwrapped.startsWith('https://') ||
+    unwrapped.startsWith('mailto:') ||
+    unwrapped.startsWith('tel:') ||
+    unwrapped.startsWith('javascript:')
+  ) {
+    return null;
+  }
+
+  const withoutQuery = unwrapped.split('?')[0];
+  const withoutFragment = withoutQuery.split('#')[0];
+  return withoutFragment.length > 0 ? withoutFragment : null;
+}
+
+function pathCandidates(basePath) {
+  if (path.extname(basePath)) {
+    return [basePath];
+  }
+  return [basePath, `${basePath}.md`, path.join(basePath, 'index.md')];
+}
+
+function resolveCandidates(target, sourceFile) {
+  if (target.startsWith('/')) {
+    const relative = target.replace(/^\/+/, '');
+    const fromDocsRoot = path.join(docsRoot, relative);
+    const fromPublic = path.join(docsRoot, 'public', relative);
+    return [...pathCandidates(fromDocsRoot), ...pathCandidates(fromPublic)];
+  }
+
+  const fromSource = path.resolve(path.dirname(sourceFile), target);
+  return pathCandidates(fromSource);
+}
+
+function isExistingFile(candidate) {
+  if (!existsSync(candidate)) {
+    return false;
+  }
+  try {
+    return statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+
+const markdownFiles = collectMarkdownFiles(docsRoot);
+const linkPattern = /\[[^\]]+\]\(([^)]+)\)/g;
+const failures = [];
+let checkedLinkCount = 0;
+
+function validateTarget(target, file, line) {
+  const normalized = normalizeLinkTarget(target);
+  if (!normalized) {
+    return;
+  }
+
+  checkedLinkCount += 1;
+  const candidates = resolveCandidates(normalized, file);
+  const exists = candidates.some(isExistingFile);
+
+  if (!exists) {
+    failures.push({
+      file,
+      line,
+      target: normalized,
+      candidates
+    });
+  }
+}
+
+for (const file of markdownFiles) {
+  const content = readFileSync(file, 'utf8');
+  const lines = content.split('\n');
+
+  lines.forEach((line, lineIndex) => {
+    const matches = line.matchAll(linkPattern);
+    for (const match of matches) {
+      validateTarget(match[1], file, lineIndex + 1);
+    }
+
+    const frontmatterLinkMatch = line.match(/^\s*link:\s*["']?([^"' ]+)["']?\s*$/);
+    if (frontmatterLinkMatch) {
+      validateTarget(frontmatterLinkMatch[1], file, lineIndex + 1);
+    }
+  });
+}
+
+const configPath = path.join(docsRoot, '.vitepress', 'config.mts');
+if (existsSync(configPath)) {
+  const configLines = readFileSync(configPath, 'utf8').split('\n');
+  configLines.forEach((line, lineIndex) => {
+    const configLinkPattern = /link:\s*['"]([^'"]+)['"]/g;
+    const matches = line.matchAll(configLinkPattern);
+    for (const match of matches) {
+      validateTarget(match[1], configPath, lineIndex + 1);
+    }
+  });
+}
+
+if (failures.length > 0) {
+  console.error(`[FAIL] broken docs links detected: ${failures.length}`);
+  for (const failure of failures) {
+    console.error(
+      `- ${path.relative(process.cwd(), failure.file)}:${failure.line} -> ${failure.target}`
+    );
+    console.error(`  checked: ${failure.candidates.map((item) => path.relative(process.cwd(), item)).join(', ')}`);
+  }
+  process.exit(1);
+}
+
+console.log(`[OK] docs links validated: ${checkedLinkCount} internal links checked across ${markdownFiles.length} markdown files.`);

--- a/website/scripts/fix-sitemap.mjs
+++ b/website/scripts/fix-sitemap.mjs
@@ -1,0 +1,73 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const sitemapPath = path.resolve(__dirname, '..', 'docs', '.vitepress', 'dist', 'sitemap.xml');
+
+function normalizeBase(value) {
+  let base = (value || '/').trim();
+  if (base.length === 0) {
+    base = '/';
+  }
+  if (!base.startsWith('/')) {
+    base = `/${base}`;
+  }
+  if (!base.endsWith('/')) {
+    base = `${base}/`;
+  }
+  return base;
+}
+
+function formatUrl(url) {
+  if (url.pathname === '/') {
+    return `${url.origin}/`;
+  }
+  const cleanPath = url.pathname.endsWith('/') ? url.pathname.slice(0, -1) : url.pathname;
+  return `${url.origin}${cleanPath}${url.search}${url.hash}`;
+}
+
+if (!existsSync(sitemapPath)) {
+  console.error(`[docs:build] sitemap not found: ${path.relative(process.cwd(), sitemapPath)}`);
+  process.exit(1);
+}
+
+const base = normalizeBase(process.env.VITEPRESS_BASE || '/');
+const siteOrigin = (process.env.VITEPRESS_SITE_ORIGIN || 'https://jaeyoung0509.github.io').replace(
+  /\/$/,
+  ''
+);
+const basePrefix = base === '/' ? '' : base.replace(/\/$/, '');
+
+if (!basePrefix) {
+  console.log('[docs:build] skip sitemap rewrite because base is "/"');
+  process.exit(0);
+}
+
+const xml = readFileSync(sitemapPath, 'utf8');
+let rewrites = 0;
+
+const rewritten = xml.replace(/<loc>([^<]+)<\/loc>/g, (fullMatch, rawUrl) => {
+  try {
+    const url = new URL(rawUrl);
+    if (url.origin !== siteOrigin) {
+      return fullMatch;
+    }
+
+    if (url.pathname === basePrefix || url.pathname.startsWith(`${basePrefix}/`)) {
+      return `<loc>${formatUrl(url)}</loc>`;
+    }
+
+    const suffix = url.pathname === '/' ? '' : url.pathname;
+    url.pathname = `${basePrefix}${suffix}`;
+    rewrites += 1;
+    return `<loc>${formatUrl(url)}</loc>`;
+  } catch {
+    return fullMatch;
+  }
+});
+
+writeFileSync(sitemapPath, rewritten, 'utf8');
+console.log(`[docs:build] sitemap rewrite complete (${rewrites} entries updated)`);

--- a/website/scripts/generate-robots.mjs
+++ b/website/scripts/generate-robots.mjs
@@ -1,0 +1,39 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function normalizeBase(value) {
+  let base = (value || '/').trim();
+  if (base.length === 0) {
+    base = '/';
+  }
+  if (!base.startsWith('/')) {
+    base = `/${base}`;
+  }
+  if (!base.endsWith('/')) {
+    base = `${base}/`;
+  }
+  return base;
+}
+
+const base = normalizeBase(process.env.VITEPRESS_BASE || '/');
+const siteOrigin = (process.env.VITEPRESS_SITE_ORIGIN || 'https://jaeyoung0509.github.io').replace(
+  /\/$/,
+  ''
+);
+const basePrefix = base === '/' ? '' : base;
+const sitemapUrl = `${siteOrigin}${basePrefix}sitemap.xml`;
+const robotsPath = path.resolve(__dirname, '..', 'docs', 'public', 'robots.txt');
+
+mkdirSync(path.dirname(robotsPath), { recursive: true });
+writeFileSync(
+  robotsPath,
+  `User-agent: *\nAllow: /\nSitemap: ${sitemapUrl}\n`,
+  'utf8'
+);
+
+console.log(`[docs:prepare] wrote ${path.relative(process.cwd(), robotsPath)} with sitemap ${sitemapUrl}`);


### PR DESCRIPTION
## Summary
- harden docs-site CI with deterministic quality gates and post-deploy validation
- add docs-site operations runbook for incident triage, local repro, and rollback/retry

## What Changed
- workflow (`.github/workflows/docs-site.yml`)
  - added docs link-check step (`npm run docs:check-links`)
  - build now uses `VITEPRESS_BASE` and `VITEPRESS_SITE_ORIGIN`
  - verifies generated `sitemap.xml` and `robots.txt`
  - verifies expected sitemap URL is present in `robots.txt`
  - added post-deploy smoke check (`./scripts/check_docs_site_smoke.sh`)
- website tooling
  - added `docs:prepare` to generate `docs/public/robots.txt`
  - added `docs:check-links` script for internal doc links and VitePress config links
  - added sitemap rewrite step so generated URLs include `/Openportio` base path
- docs/runbook
  - added `docs/release/docs-site-runbook.md` with local reproduction, failure triage, rollback/retry workflow
  - updated `docs/ci-workflow.md` and `website/README.md`

## Validation
- `cd website && npm run docs:check-links`
- `cd website && VITEPRESS_BASE=/Openportio/ VITEPRESS_SITE_ORIGIN=https://jaeyoung0509.github.io npm run docs:build`
- local smoke:
  - `./scripts/check_docs_site_smoke.sh http://127.0.0.1:4173/Openportio/ Openportio`

Closes #77
