### PR TITLE
chore(security): add SECURITY.md and support policy (#81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ If you are evaluating Openportio for production, use this order:
    - `docs/fastapi-like-builder.md`
    - `/openapi.json`, `/docs`, `/grpc/contracts`, `/grpc/contracts/openapi.json`
 3. Production operating baseline:
+   - `SECURITY.md`
    - `docs/production/deployment.md`
    - `docs/production/security.md`
    - `docs/production/runbook.md`
@@ -431,6 +432,7 @@ Use this index for fast incident routing:
 
 ## Production Readiness Docs
 
+- `SECURITY.md`
 - `docs/production/deployment.md`
 - `docs/production/security.md`
 - `docs/production/observability.md`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,6 @@ When feasible, fixes land on `develop` first and are included in the next releas
 ## Operator Notes
 
 For runtime hardening guidance, see:
-- `/Users/apple/Myproject/alloy/docs/production/security.md`
-- `/Users/apple/Myproject/alloy/docs/production/deployment.md`
-- `/Users/apple/Myproject/alloy/docs/production/runbook.md`
+- `docs/production/security.md`
+- `docs/production/deployment.md`
+- `docs/production/runbook.md`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+This document defines how to report vulnerabilities in Openportio and what support window to expect.
+
+## Reporting A Vulnerability
+
+Preferred channel:
+- Use GitHub private vulnerability reporting for this repository:
+  - <https://github.com/jaeyoung0509/Openportio/security/advisories/new>
+
+Please include:
+- affected crate(s) and version/commit
+- impact summary (confidentiality/integrity/availability)
+- reproduction steps or proof-of-concept
+- suggested fix direction (if available)
+
+Do not open public issues for unpatched vulnerabilities.
+
+If private reporting is unavailable for any reason, open a minimal public issue without exploit details and request a private contact channel from maintainers.
+
+## Response Expectations
+
+- Initial acknowledgement: within 72 hours
+- Triage decision: within 7 calendar days
+- Status updates: at least weekly for active incidents
+
+Resolution timeline depends on severity and release risk, but critical issues are prioritized immediately.
+
+## Supported Versions
+
+Openportio is pre-1.0 (`0.y.z`). Security fixes are focused on the latest release line.
+
+| Version / Branch | Security Support |
+| --- | --- |
+| Latest `0.y.z` release on `main` | Supported |
+| `develop` branch | Best effort (may change quickly) |
+| Older release lines | Not supported |
+
+When feasible, fixes land on `develop` first and are included in the next release.
+
+## Disclosure Process
+
+- We follow coordinated disclosure by default.
+- Report details are kept private until a fix or mitigation is available.
+- Advisory publication timing is coordinated with patch release.
+- Reporters are credited in advisories/releases when requested.
+
+## Operator Notes
+
+For runtime hardening guidance, see:
+- `/Users/apple/Myproject/alloy/docs/production/security.md`
+- `/Users/apple/Myproject/alloy/docs/production/deployment.md`
+- `/Users/apple/Myproject/alloy/docs/production/runbook.md`

--- a/docs/production/security.md
+++ b/docs/production/security.md
@@ -1,6 +1,7 @@
 # Security Baseline
 
 This page defines a practical secure baseline for deploying Openportio.
+For vulnerability disclosure/support scope, see `/Users/apple/Myproject/alloy/SECURITY.md`.
 
 ## Authentication
 

--- a/docs/production/security.md
+++ b/docs/production/security.md
@@ -1,7 +1,7 @@
 # Security Baseline
 
 This page defines a practical secure baseline for deploying Openportio.
-For vulnerability disclosure/support scope, see `/Users/apple/Myproject/alloy/SECURITY.md`.
+For vulnerability disclosure/support scope, see `../../SECURITY.md`.
 
 ## Authentication
 


### PR DESCRIPTION
## Summary
- add a top-level `SECURITY.md` as canonical vulnerability disclosure/support policy
- link security policy from README and production security docs
- define response expectations and supported-version scope for pre-1.0 releases

## What Changed
- added `/SECURITY.md` with:
  - private vulnerability reporting channel
  - required report content
  - acknowledgement/triage/update timelines
  - supported version matrix
  - coordinated disclosure process
- updated `/README.md` to include `SECURITY.md` in production-first navigation and production docs index
- updated `/docs/production/security.md` to reference `SECURITY.md` for disclosure/support scope

## Validation
- `cargo check --workspace`
- `cd website && npm run docs:check-links`

Closes #81
