### PR TITLE
chore(release): harden develop->main release workflow and publish gates (#86)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,5 +189,18 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      - name: Validate release metadata consistency
+        run: ./scripts/check_release_metadata.sh
+
       - name: Validate publish dry-run for release crates
         run: ./scripts/release_dry_run.sh
+
+      - name: Upload release dry-run artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dry-run-artifacts
+          path: |
+            target/release/metadata-summary.md
+            target/release/dry-run-summary.md
+            target/release/dry-run-logs/*.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
+      - name: Validate release metadata and tag consistency
+        env:
+          OPENPORTIO_RELEASE_TAG: ${{ github.ref_name }}
+        run: ./scripts/check_release_metadata.sh
+
       - name: Ensure tag commit is reachable from main
         run: |
           set -euo pipefail
@@ -39,6 +44,8 @@ jobs:
           fi
 
       - name: Validate release gates
+        env:
+          OPENPORTIO_RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           cargo fmt --all -- --check
@@ -59,6 +66,16 @@ jobs:
           OPENPORTIO_MAX_IN_FLIGHT_REQUESTS=1024 \
           ./scripts/prod_preflight.sh
           ./scripts/release_dry_run.sh
+
+      - name: Upload release preflight artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-preflight-${{ github.ref_name }}
+          path: |
+            target/release/metadata-summary.md
+            target/release/dry-run-summary.md
+            target/release/dry-run-logs/*.log
 
       - name: Publish crates in dependency order
         env:

--- a/docs/release/publish-runbook.md
+++ b/docs/release/publish-runbook.md
@@ -20,6 +20,7 @@ Examples are intentionally non-publishable (`publish = false`).
 Run from repository root:
 
 ```bash
+./scripts/check_release_metadata.sh
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
@@ -28,7 +29,14 @@ cargo test --workspace
 ./scripts/release_dry_run.sh
 ```
 
+For a specific release tag candidate, run metadata validation with tag consistency:
+
+```bash
+OPENPORTIO_RELEASE_TAG=v0.1.0 ./scripts/check_release_metadata.sh
+```
+
 `scripts/release_dry_run.sh` does:
+- executes `scripts/check_release_metadata.sh` as a mandatory first gate
 - `cargo publish --dry-run` for all publishable crates:
   - `openportio-core`
   - `openportio-macros`
@@ -36,6 +44,10 @@ cargo test --workspace
   - `openportio-server`
 - applies local `patch.crates-io` overrides so dry-run can validate dependent crates
   before first crates.io index propagation.
+- writes audit artifacts:
+  - `target/release/metadata-summary.md`
+  - `target/release/dry-run-summary.md`
+  - `target/release/dry-run-logs/*.log`
 
 ## Publish Order
 
@@ -55,9 +67,20 @@ cargo publish -p openportio-rpc
 cargo publish -p openportio-server
 ```
 
-## Automated GitHub Release Path (Recommended)
+## Enforced Release Sequence (Develop -> Main -> Tag)
 
-This repository includes tag-driven automation in `.github/workflows/release.yml`.
+This repository uses a strict release sequence:
+
+1. Merge feature PRs into `develop`.
+2. Open and merge a `develop -> main` release PR.
+3. Create and push release tag from `main`.
+4. Let `.github/workflows/release.yml` publish crates + GitHub release.
+
+The release workflow is tag-driven and rejects tags not reachable from `main`.
+It also enforces:
+- metadata/tag/changelog consistency (`scripts/check_release_metadata.sh`)
+- full quality gates
+- publish dry-run gates (`scripts/release_dry_run.sh`)
 
 Prerequisites:
 - GitHub Actions secret: `CRATES_IO_TOKEN`
@@ -78,8 +101,10 @@ git push origin v0.1.0
 
 3. GitHub Actions will:
 - re-run release quality gates
+- validate metadata/tag/changelog consistency early
 - publish crates in dependency order (`openportio-core` -> `openportio-macros` -> `openportio-rpc` -> `openportio-server`)
 - create/update GitHub release notes
+- upload release preflight artifacts (`target/release/*.md`, dry-run logs)
 
 The workflow rejects tags that are not reachable from `main`.
 

--- a/docs/release/versioning.md
+++ b/docs/release/versioning.md
@@ -24,6 +24,22 @@ Each release should include:
 - security-impacting changes
 - CI/release pipeline updates
 
+## Metadata Consistency Gates
+
+Release automation enforces:
+- tag format: `vX.Y.Z` or `vX.Y.Z-rc.N`
+- tag version equals `[workspace.package].version`
+- `CHANGELOG.md` includes `## [Unreleased]`
+- when a tag is provided, `CHANGELOG.md` includes `## [<tag-version>]`
+- publishable crate dependency pins (`openportio-*`) align to workspace version
+
+Run locally:
+
+```bash
+./scripts/check_release_metadata.sh
+OPENPORTIO_RELEASE_TAG=v0.1.0 ./scripts/check_release_metadata.sh
+```
+
 ## Rename Migration (Meld -> Openportio)
 
 - Crate names moved to `openportio-*`.

--- a/scripts/check_release_metadata.sh
+++ b/scripts/check_release_metadata.sh
@@ -105,7 +105,11 @@ for crate in "${release_crates[@]}"; do
         "${manifest} has ${dep_name} dependency version ${dep_version} (expected ${workspace_version})"
       )
     fi
-  done < <(rg -n 'openportio-(core|macros|rpc|server)\s*=\s*\{[^}]*version\s*=\s*"[^"]+"' "$manifest" || true)
+  done < <(
+    grep -E \
+      'openportio-(core|macros|rpc|server)[[:space:]]*=[[:space:]]*\{[^}]*version[[:space:]]*=[[:space:]]*"[^"]+"' \
+      "$manifest" || true
+  )
 done
 
 {

--- a/scripts/check_release_metadata.sh
+++ b/scripts/check_release_metadata.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+OUTPUT_DIR="${ROOT_DIR}/target/release"
+SUMMARY_FILE="${OPENPORTIO_RELEASE_METADATA_SUMMARY:-${OUTPUT_DIR}/metadata-summary.md}"
+RELEASE_TAG="${OPENPORTIO_RELEASE_TAG:-}"
+
+mkdir -p "$(dirname "$SUMMARY_FILE")"
+
+failures=()
+
+workspace_version="$(
+  awk '
+    $0 ~ /^\[workspace\.package\]/ { in_workspace_package = 1; next }
+    /^\[/ && in_workspace_package { in_workspace_package = 0 }
+    in_workspace_package && $1 == "version" {
+      gsub(/"/, "", $3)
+      print $3
+      exit
+    }
+  ' Cargo.toml
+)"
+
+if [[ -z "$workspace_version" ]]; then
+  failures+=("failed to resolve [workspace.package].version from Cargo.toml")
+fi
+
+tag_version=""
+if [[ -n "$RELEASE_TAG" ]]; then
+  if [[ "$RELEASE_TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-rc\.[0-9]+)?$ ]]; then
+    tag_version="${RELEASE_TAG#v}"
+    if [[ -n "$workspace_version" && "$tag_version" != "$workspace_version" ]]; then
+      failures+=(
+        "release tag version (${tag_version}) does not match workspace version (${workspace_version})"
+      )
+    fi
+  else
+    failures+=("release tag '${RELEASE_TAG}' is invalid (expected vX.Y.Z or vX.Y.Z-rc.N)")
+  fi
+fi
+
+if ! grep -q '^## \[Unreleased\]' CHANGELOG.md; then
+  failures+=("CHANGELOG.md is missing required '## [Unreleased]' section")
+fi
+
+if [[ -n "$tag_version" ]]; then
+  escaped_tag_version="$(printf '%s\n' "$tag_version" | sed 's/\./\\./g')"
+  if ! grep -Eq "^## \\[${escaped_tag_version}\\]" CHANGELOG.md; then
+    failures+=("CHANGELOG.md is missing section for release version '${tag_version}'")
+  fi
+fi
+
+release_crates=(
+  "openportio-core"
+  "openportio-macros"
+  "openportio-rpc"
+  "openportio-server"
+)
+
+crate_rows=()
+for crate in "${release_crates[@]}"; do
+  manifest="crates/${crate}/Cargo.toml"
+
+  if [[ ! -f "$manifest" ]]; then
+    failures+=("missing crate manifest: ${manifest}")
+    crate_rows+=("| ${crate} | missing manifest | - |")
+    continue
+  fi
+
+  if grep -Eq '^version\.workspace\s*=\s*true$' "$manifest"; then
+    crate_rows+=("| ${crate} | workspace | ${workspace_version:-unknown} |")
+  else
+    crate_version="$(
+      awk '
+        $0 ~ /^\[package\]/ { in_package = 1; next }
+        /^\[/ && in_package { in_package = 0 }
+        in_package && $1 == "version" {
+          gsub(/"/, "", $3)
+          print $3
+          exit
+        }
+      ' "$manifest"
+    )"
+    if [[ -z "$crate_version" ]]; then
+      failures+=("${manifest} missing package version")
+      crate_rows+=("| ${crate} | explicit | missing |")
+    elif [[ -n "$workspace_version" && "$crate_version" != "$workspace_version" ]]; then
+      failures+=(
+        "${manifest} package version (${crate_version}) does not match workspace version (${workspace_version})"
+      )
+      crate_rows+=("| ${crate} | explicit | ${crate_version} (mismatch) |")
+    else
+      crate_rows+=("| ${crate} | explicit | ${crate_version} |")
+    fi
+  fi
+
+  while IFS= read -r line; do
+    dep_name="$(printf '%s\n' "$line" | sed -E 's/.*(openportio-[a-z]+)[[:space:]]*=[[:space:]]*\{.*/\1/')"
+    dep_version="$(printf '%s\n' "$line" | sed -E 's/.*version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
+    if [[ -n "$workspace_version" && "$dep_version" != "$workspace_version" ]]; then
+      failures+=(
+        "${manifest} has ${dep_name} dependency version ${dep_version} (expected ${workspace_version})"
+      )
+    fi
+  done < <(rg -n 'openportio-(core|macros|rpc|server)\s*=\s*\{[^}]*version\s*=\s*"[^"]+"' "$manifest" || true)
+done
+
+{
+  echo "# Release Metadata Summary"
+  echo
+  echo "- Workspace version: \`${workspace_version:-unresolved}\`"
+  if [[ -n "$RELEASE_TAG" ]]; then
+    echo "- Release tag input: \`${RELEASE_TAG}\`"
+  else
+    echo "- Release tag input: _(not provided)_"
+  fi
+  echo
+  echo "## Release Crate Versions"
+  echo
+  echo "| crate | version source | version |"
+  echo "|---|---|---|"
+  for row in "${crate_rows[@]}"; do
+    echo "$row"
+  done
+  echo
+  if [[ "${#failures[@]}" -eq 0 ]]; then
+    echo "## Result"
+    echo
+    echo "[PASS] release metadata checks passed."
+  else
+    echo "## Result"
+    echo
+    echo "[FAIL] release metadata checks failed:"
+    for failure in "${failures[@]}"; do
+      echo "- ${failure}"
+    done
+  fi
+} > "$SUMMARY_FILE"
+
+echo "Release metadata summary: ${SUMMARY_FILE}"
+
+if [[ "${#failures[@]}" -ne 0 ]]; then
+  exit 1
+fi

--- a/scripts/release_dry_run.sh
+++ b/scripts/release_dry_run.sh
@@ -24,16 +24,12 @@ SERVER_PATCH_ARGS=(
 )
 
 workspace_version="$(
-  awk '
-    $0 ~ /^\[workspace\.package\]/ { in_workspace_package = 1; next }
-    /^\[/ && in_workspace_package { in_workspace_package = 0 }
-    in_workspace_package && $1 == "version" {
-      gsub(/"/, "", $3)
-      print $3
-      exit
-    }
-  ' Cargo.toml
+  sed -n 's/^- Workspace version: `\([^`]*\)`/\1/p' "$METADATA_SUMMARY_FILE"
 )"
+if [[ -z "$workspace_version" || "$workspace_version" == "unresolved" ]]; then
+  echo "[FAIL] could not determine workspace version from ${METADATA_SUMMARY_FILE}" >&2
+  exit 1
+fi
 
 release_tag="${OPENPORTIO_RELEASE_TAG:-}"
 dry_run_rows=()

--- a/scripts/release_dry_run.sh
+++ b/scripts/release_dry_run.sh
@@ -4,6 +4,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+OUTPUT_DIR="${ROOT_DIR}/target/release"
+LOG_DIR="${OUTPUT_DIR}/dry-run-logs"
+SUMMARY_FILE="${OPENPORTIO_RELEASE_DRY_RUN_SUMMARY:-${OUTPUT_DIR}/dry-run-summary.md}"
+METADATA_SUMMARY_FILE="${OPENPORTIO_RELEASE_METADATA_SUMMARY:-${OUTPUT_DIR}/metadata-summary.md}"
+
+mkdir -p "$LOG_DIR"
+
+./scripts/check_release_metadata.sh
+
 RPC_PATCH_ARGS=(
   --config "patch.crates-io.openportio-core.path=\"crates/openportio-core\""
 )
@@ -14,17 +23,73 @@ SERVER_PATCH_ARGS=(
   --config "patch.crates-io.openportio-rpc.path=\"crates/openportio-rpc\""
 )
 
-echo "[1/4] cargo publish --dry-run -p openportio-core --allow-dirty"
-cargo publish --dry-run -p openportio-core --allow-dirty
+workspace_version="$(
+  awk '
+    $0 ~ /^\[workspace\.package\]/ { in_workspace_package = 1; next }
+    /^\[/ && in_workspace_package { in_workspace_package = 0 }
+    in_workspace_package && $1 == "version" {
+      gsub(/"/, "", $3)
+      print $3
+      exit
+    }
+  ' Cargo.toml
+)"
 
-echo "[2/4] cargo publish --dry-run -p openportio-macros --allow-dirty"
-cargo publish --dry-run -p openportio-macros --allow-dirty
+release_tag="${OPENPORTIO_RELEASE_TAG:-}"
+dry_run_rows=()
+dry_run_failed=0
 
-echo "[3/4] cargo publish --dry-run -p openportio-rpc --allow-dirty"
-cargo publish --dry-run -p openportio-rpc --allow-dirty "${RPC_PATCH_ARGS[@]}"
+run_dry_run() {
+  local step="$1"
+  local crate="$2"
+  shift 2
+  local log_file="${LOG_DIR}/${step}-${crate}.log"
 
-echo "[4/4] cargo publish --dry-run -p openportio-server --allow-dirty"
-cargo publish --dry-run -p openportio-server --allow-dirty "${SERVER_PATCH_ARGS[@]}"
+  echo "[${step}/4] cargo publish --dry-run -p ${crate} --allow-dirty"
+  if cargo publish --dry-run -p "${crate}" --allow-dirty "$@" 2>&1 | tee "${log_file}"; then
+    dry_run_rows+=("| ${crate} | pass | ${log_file#${ROOT_DIR}/} |")
+  else
+    dry_run_rows+=("| ${crate} | fail | ${log_file#${ROOT_DIR}/} |")
+    dry_run_failed=1
+  fi
+}
 
-echo "Release readiness checks succeeded."
-echo "Note: local crates.io patch overrides are used to validate publish order before first registry index propagation."
+run_dry_run 1 openportio-core
+
+run_dry_run 2 openportio-macros
+
+run_dry_run 3 openportio-rpc "${RPC_PATCH_ARGS[@]}"
+
+run_dry_run 4 openportio-server "${SERVER_PATCH_ARGS[@]}"
+
+{
+  echo "# Release Dry-Run Summary"
+  echo
+  echo "- Workspace version: \`${workspace_version:-unresolved}\`"
+  if [[ -n "$release_tag" ]]; then
+    echo "- Release tag input: \`${release_tag}\`"
+  else
+    echo "- Release tag input: _(not provided)_"
+  fi
+  echo "- Metadata summary: \`${METADATA_SUMMARY_FILE#${ROOT_DIR}/}\`"
+  echo
+  echo "| crate | result | log |"
+  echo "|---|---|---|"
+  for row in "${dry_run_rows[@]}"; do
+    echo "$row"
+  done
+  echo
+  if [[ "$dry_run_failed" -eq 0 ]]; then
+    echo "[PASS] release dry-run checks succeeded."
+    echo
+    echo "Note: local crates.io patch overrides are used to validate publish order before first registry index propagation."
+  else
+    echo "[FAIL] release dry-run checks failed. Check logs above."
+  fi
+} > "$SUMMARY_FILE"
+
+echo "Release dry-run summary: ${SUMMARY_FILE}"
+
+if [[ "$dry_run_failed" -ne 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `scripts/check_release_metadata.sh` to enforce release metadata consistency gates
- wire metadata validation into CI (`Release Dry Run` job) and tag release workflow
- harden `scripts/release_dry_run.sh` to always run metadata checks first
- generate auditable release artifacts:
  - `target/release/metadata-summary.md`
  - `target/release/dry-run-summary.md`
  - `target/release/dry-run-logs/*.log`
- strengthen release docs for enforced `develop -> main -> tag` sequence and rollback/readiness guidance

## Validation
- `./scripts/check_release_metadata.sh`
- `./scripts/release_dry_run.sh`
- `OPENPORTIO_RELEASE_TAG=v0.1.0 ./scripts/check_release_metadata.sh` (expected failure now, because `CHANGELOG.md` has no `## [0.1.0]` section yet)

Closes #86
