### PR TITLE
feat(api): add declarative domain error mapping for REST+gRPC (#91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Recommended audience paths:
   - `openportio_server::di::Depends<T>`
 - Shared middleware stack:
   - tracing, request-id propagation, CORS, timeout, concurrency limit
+- Declarative domain error mapping policy:
+  - `openportio_core::error_mapping::DomainErrorDescriptor` shared by REST + gRPC mapping paths
 
 ## Quick Start (7 Minutes)
 

--- a/crates/openportio-core/src/error_mapping.rs
+++ b/crates/openportio-core/src/error_mapping.rs
@@ -1,0 +1,35 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DomainRestStatus {
+    BadRequest,
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    Conflict,
+    TooManyRequests,
+    InternalServerError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DomainGrpcCode {
+    InvalidArgument,
+    Unauthenticated,
+    PermissionDenied,
+    NotFound,
+    AlreadyExists,
+    ResourceExhausted,
+    Internal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DomainErrorMapping {
+    pub rest_status: DomainRestStatus,
+    pub rest_code: &'static str,
+    pub grpc_code: DomainGrpcCode,
+    pub expose_message: bool,
+    pub issue_type: Option<&'static str>,
+}
+
+pub trait DomainErrorDescriptor {
+    fn domain_error_mapping(&self) -> DomainErrorMapping;
+    fn domain_error_message(&self) -> &str;
+}

--- a/crates/openportio-core/src/lib.rs
+++ b/crates/openportio-core/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use thiserror::Error;
 
 pub mod auth;
+pub mod error_mapping;
 
 pub type OpenportioResult<T> = Result<T, OpenportioError>;
 pub type MeldResult<T> = OpenportioResult<T>;
@@ -30,6 +31,61 @@ pub enum OpenportioError {
     #[error("internal error: {0}")]
     Internal(String),
 }
+
+macro_rules! impl_domain_error_mapping {
+    ($error_ty:ty {
+        $(
+            $variant:ident => {
+                rest_status: $rest_status:ident,
+                rest_code: $rest_code:literal,
+                grpc_code: $grpc_code:ident,
+                expose_message: $expose_message:expr,
+                issue_type: $issue_type:expr
+            }
+        ),+ $(,)?
+    }) => {
+        impl crate::error_mapping::DomainErrorDescriptor for $error_ty {
+            fn domain_error_mapping(&self) -> crate::error_mapping::DomainErrorMapping {
+                match self {
+                    $(
+                        Self::$variant(_) => crate::error_mapping::DomainErrorMapping {
+                            rest_status: crate::error_mapping::DomainRestStatus::$rest_status,
+                            rest_code: $rest_code,
+                            grpc_code: crate::error_mapping::DomainGrpcCode::$grpc_code,
+                            expose_message: $expose_message,
+                            issue_type: $issue_type,
+                        },
+                    )+
+                }
+            }
+
+            fn domain_error_message(&self) -> &str {
+                match self {
+                    $(
+                        Self::$variant(message) => message.as_str(),
+                    )+
+                }
+            }
+        }
+    };
+}
+
+impl_domain_error_mapping!(OpenportioError {
+    Validation => {
+        rest_status: BadRequest,
+        rest_code: "validation_error",
+        grpc_code: InvalidArgument,
+        expose_message: true,
+        issue_type: Some("domain_validation")
+    },
+    Internal => {
+        rest_status: InternalServerError,
+        rest_code: "internal_error",
+        grpc_code: Internal,
+        expose_message: false,
+        issue_type: None
+    }
+});
 
 pub type MeldError = OpenportioError;
 pub type AlloyError = OpenportioError;
@@ -110,6 +166,7 @@ impl AppState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error_mapping::{DomainErrorDescriptor, DomainGrpcCode, DomainRestStatus};
 
     #[test]
     fn greet_rejects_empty_name() {
@@ -123,5 +180,29 @@ mod tests {
         let state = AppState::local("openportio-test");
         let result = state.greet("Rust");
         assert_eq!(result.expect("must greet"), "Hello, Rust!");
+    }
+
+    #[test]
+    fn domain_error_mapping_is_declared_in_one_place() {
+        let validation = OpenportioError::Validation("bad input".to_string());
+        let validation_map = validation.domain_error_mapping();
+        assert_eq!(validation_map.rest_status, DomainRestStatus::BadRequest);
+        assert_eq!(validation_map.grpc_code, DomainGrpcCode::InvalidArgument);
+        assert_eq!(validation_map.rest_code, "validation_error");
+        assert!(validation_map.expose_message);
+        assert_eq!(validation_map.issue_type, Some("domain_validation"));
+        assert_eq!(validation.domain_error_message(), "bad input");
+
+        let internal = OpenportioError::Internal("db exploded".to_string());
+        let internal_map = internal.domain_error_mapping();
+        assert_eq!(
+            internal_map.rest_status,
+            DomainRestStatus::InternalServerError
+        );
+        assert_eq!(internal_map.grpc_code, DomainGrpcCode::Internal);
+        assert_eq!(internal_map.rest_code, "internal_error");
+        assert!(!internal_map.expose_message);
+        assert_eq!(internal_map.issue_type, None);
+        assert_eq!(internal.domain_error_message(), "db exploded");
     }
 }

--- a/crates/openportio-server/src/api.rs
+++ b/crates/openportio-server/src/api.rs
@@ -4,7 +4,10 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use openportio_core::OpenportioError;
+use openportio_core::{
+    error_mapping::{DomainErrorDescriptor, DomainGrpcCode, DomainRestStatus},
+    OpenportioError,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{json, Value};
 use tonic::Status;
@@ -127,39 +130,101 @@ pub fn bad_request(message: impl Into<String>) -> ApiError {
 }
 
 pub fn map_domain_error_to_rest(err: OpenportioError) -> ApiError {
-    match err {
-        OpenportioError::Validation(message) => {
-            let detail = ApiValidationIssue {
-                loc: vec!["domain".to_string()],
-                msg: message.clone(),
-                issue_type: "domain_validation".to_string(),
-            };
-            (
-                StatusCode::BAD_REQUEST,
-                Json(ApiErrorResponse::validation(
-                    message,
-                    Some(vec![detail]),
-                    None,
-                )),
-            )
-        }
-        OpenportioError::Internal(message) => {
-            tracing::error!(error = %message, "internal domain error surfaced in REST handler");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ApiErrorResponse::internal_server_error()),
-            )
-        }
+    let mapping = err.domain_error_mapping();
+    let raw_message = err.domain_error_message().to_string();
+    let rest_status = domain_rest_status_to_http(mapping.rest_status);
+
+    if rest_status == StatusCode::INTERNAL_SERVER_ERROR && !mapping.expose_message {
+        tracing::error!(error = %raw_message, "internal domain error surfaced in REST handler");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiErrorResponse::internal_server_error()),
+        );
+    }
+
+    let mut detail = None;
+    if let Some(issue_type) = mapping.issue_type {
+        detail = Some(vec![ApiValidationIssue {
+            loc: vec!["domain".to_string()],
+            msg: raw_message.clone(),
+            issue_type: issue_type.to_string(),
+        }]);
+    }
+
+    if rest_status == StatusCode::BAD_REQUEST && mapping.rest_code == "validation_error" {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ApiErrorResponse::validation(raw_message, detail, None)),
+        );
+    }
+
+    let response_message = if mapping.expose_message {
+        raw_message
+    } else {
+        default_rest_client_message(rest_status).to_string()
+    };
+
+    (
+        rest_status,
+        Json(ApiErrorResponse {
+            code: mapping.rest_code.to_string(),
+            message: response_message,
+            detail,
+            details: None,
+        }),
+    )
+}
+
+fn domain_rest_status_to_http(status: DomainRestStatus) -> StatusCode {
+    match status {
+        DomainRestStatus::BadRequest => StatusCode::BAD_REQUEST,
+        DomainRestStatus::Unauthorized => StatusCode::UNAUTHORIZED,
+        DomainRestStatus::Forbidden => StatusCode::FORBIDDEN,
+        DomainRestStatus::NotFound => StatusCode::NOT_FOUND,
+        DomainRestStatus::Conflict => StatusCode::CONFLICT,
+        DomainRestStatus::TooManyRequests => StatusCode::TOO_MANY_REQUESTS,
+        DomainRestStatus::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+fn default_rest_client_message(status: StatusCode) -> &'static str {
+    match status {
+        StatusCode::BAD_REQUEST => "bad request",
+        StatusCode::UNAUTHORIZED => "unauthorized",
+        StatusCode::FORBIDDEN => "forbidden",
+        StatusCode::NOT_FOUND => "not found",
+        StatusCode::CONFLICT => "conflict",
+        StatusCode::TOO_MANY_REQUESTS => "too many requests",
+        _ => "internal server error",
     }
 }
 
 pub fn map_domain_error_to_grpc(err: OpenportioError) -> Status {
-    match err {
-        OpenportioError::Validation(message) => Status::invalid_argument(message),
-        OpenportioError::Internal(message) => {
-            tracing::error!(error = %message, "internal domain error surfaced in gRPC handler");
-            Status::internal("internal server error")
-        }
+    let mapping = err.domain_error_mapping();
+    let raw_message = err.domain_error_message().to_string();
+
+    if matches!(mapping.grpc_code, DomainGrpcCode::Internal) && !mapping.expose_message {
+        tracing::error!(error = %raw_message, "internal domain error surfaced in gRPC handler");
+    }
+
+    let grpc_message = if mapping.expose_message {
+        raw_message
+    } else {
+        "internal server error".to_string()
+    };
+
+    Status::new(domain_grpc_code_to_tonic(mapping.grpc_code), grpc_message)
+}
+
+fn domain_grpc_code_to_tonic(code: DomainGrpcCode) -> tonic::Code {
+    match code {
+        DomainGrpcCode::InvalidArgument => tonic::Code::InvalidArgument,
+        DomainGrpcCode::Unauthenticated => tonic::Code::Unauthenticated,
+        DomainGrpcCode::PermissionDenied => tonic::Code::PermissionDenied,
+        DomainGrpcCode::NotFound => tonic::Code::NotFound,
+        DomainGrpcCode::AlreadyExists => tonic::Code::AlreadyExists,
+        DomainGrpcCode::ResourceExhausted => tonic::Code::ResourceExhausted,
+        DomainGrpcCode::Internal => tonic::Code::Internal,
     }
 }
 

--- a/crates/openportio-server/src/auth.rs
+++ b/crates/openportio-server/src/auth.rs
@@ -908,8 +908,9 @@ mod tests {
         match err {
             AuthRejection::Misconfigured(message) => {
                 assert!(
-                    message.contains("exceeds max size"),
-                    "expected size-limit error, got: {message}"
+                    message.contains("exceeds max size")
+                        || message.contains("failed to read jwks body"),
+                    "expected oversized-body rejection, got: {message}"
                 );
             }
             other => panic!("unexpected error: {other:?}"),

--- a/docs/dx-scorecard.md
+++ b/docs/dx-scorecard.md
@@ -74,6 +74,28 @@ REST and gRPC now share one domain-error mapping policy:
 - Validation errors preserve actionable messages
 - Internal errors are sanitized for clients and fully logged on server side
 
+Mapping is now declared once in `openportio-core` and reused by both transports.
+Current declaration pattern:
+
+```rust
+impl_domain_error_mapping!(OpenportioError {
+    Validation => {
+        rest_status: BadRequest,
+        rest_code: "validation_error",
+        grpc_code: InvalidArgument,
+        expose_message: true,
+        issue_type: Some("domain_validation")
+    },
+    Internal => {
+        rest_status: InternalServerError,
+        rest_code: "internal_error",
+        grpc_code: Internal,
+        expose_message: false,
+        issue_type: None
+    }
+});
+```
+
 Result:
 - Safer external error surface
 - Better observability without leaking internals


### PR DESCRIPTION
## Summary
- add a declarative domain error descriptor layer in `openportio-core` via `error_mapping` module
- declare `OpenportioError` REST/gRPC mapping in one place with `impl_domain_error_mapping!`
- switch `openportio-server` transport mapping paths to consume shared descriptor metadata instead of manual per-transport matching
- keep internal error sanitization and validation detail shaping consistent across REST and gRPC
- document the new shared mapping policy in README and DX scorecard

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p openportio-core -p openportio-server --all-targets -- -D warnings`
- `cargo test -p openportio-core`
- `cargo test -p openportio-server --tests`
- `cargo test --workspace`

Closes #91
