### PR TITLE
feat(macros): improve macro transparency and debug ergonomics (#93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,25 @@ impl RequestValidation for CreateNoteBody {
 }
 ```
 
+### Route Auto-Validate Modes
+
+Openportio supports two route macro styles:
+- `auto_validate` (legacy-compatible): rewrites `Json/Query/Path` into validated extractors.
+- `auto_validate, transparent` (recommended): no hidden rewrite; you write explicit validated extractors.
+
+Transparent mode example:
+
+```rust
+use openportio_server::api::{ApiError, ValidatedJson};
+
+#[openportio_server::route(post, "/notes", auto_validate, transparent)]
+async fn create_note(
+    ValidatedJson(body): ValidatedJson<CreateNoteBody>,
+) -> Result<axum::Json<String>, ApiError> {
+    Ok(axum::Json(body.title))
+}
+```
+
 ### Raw Axum/Tonic Escape Hatches
 
 ```rust

--- a/crates/openportio-macros/src/lib.rs
+++ b/crates/openportio-macros/src/lib.rs
@@ -14,6 +14,7 @@ struct RouteArgs {
     method: RouteMethod,
     path: LitStr,
     auto_validate: bool,
+    transparent: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -85,19 +86,37 @@ impl Parse for RouteArgs {
             .map_err(|_| Error::new(input.span(), "route path must be a string literal"))?;
 
         let mut auto_validate = false;
+        let mut transparent = false;
         while !input.is_empty() {
             input.parse::<Token![,]>()?;
             let flag: Ident = input.parse()?;
             match flag.to_string().as_str() {
                 "auto_validate" => auto_validate = true,
-                _ => return Err(Error::new(flag.span(), format!("unknown flag `{}`", flag))),
+                "transparent" => transparent = true,
+                _ => {
+                    return Err(Error::new(
+                        flag.span(),
+                        format!(
+                            "unknown flag `{}`; supported flags are: auto_validate, transparent",
+                            flag
+                        ),
+                    ))
+                }
             }
+        }
+
+        if transparent && !auto_validate {
+            return Err(Error::new(
+                method_ident.span(),
+                "`transparent` requires `auto_validate`; use `#[route(..., auto_validate, transparent)]`",
+            ));
         }
 
         Ok(Self {
             method,
             path,
             auto_validate,
+            transparent,
         })
     }
 }
@@ -112,7 +131,12 @@ pub fn route(args: TokenStream, item: TokenStream) -> TokenStream {
             Ok(path) => path,
             Err(err) => return err.to_compile_error().into(),
         };
-        if let Err(err) = apply_auto_validate(&mut item_fn, &server_crate) {
+        let apply_result = if parsed.transparent {
+            apply_transparent_auto_validate(&item_fn)
+        } else {
+            apply_auto_validate(&mut item_fn, &server_crate)
+        };
+        if let Err(err) = apply_result {
             return err.to_compile_error().into();
         }
     }
@@ -166,7 +190,8 @@ fn resolve_openportio_server_path() -> syn::Result<syn::Path> {
         Err(_) => Err(Error::new(
             Span::call_site(),
             "failed to resolve `openportio-server` crate for `#[route(..., auto_validate)]`; \
-             ensure `openportio-server` (or legacy `alloy-server`) is present in Cargo.toml dependencies",
+             ensure `openportio-server` (or legacy `alloy-server`) is present in Cargo.toml dependencies. \
+             if you use the crate rename path (`openportio = { package = \"openportio-server\", ... }`), keep that dependency public to macro expansion",
         )),
     }
 }
@@ -242,6 +267,41 @@ fn apply_auto_validate(item_fn: &mut ItemFn, server_crate: &syn::Path) -> syn::R
     }
 }
 
+fn apply_transparent_auto_validate(item_fn: &ItemFn) -> syn::Result<()> {
+    let mut errors: Option<syn::Error> = None;
+
+    for input in &item_fn.sig.inputs {
+        let FnArg::Typed(arg) = input else {
+            continue;
+        };
+        let Some(segment) = last_type_segment(&arg.ty) else {
+            continue;
+        };
+
+        let name = segment.ident.to_string();
+        let Some(kind) = ExtractorKind::parse(&name) else {
+            continue;
+        };
+        let validated = kind.validated_ident();
+        let source = kind.source_ident();
+        let message = format!(
+            "transparent auto_validate mode does not rewrite extractors; replace `{source}<T>` with `{validated}<T>` in the handler signature, or remove `transparent` to keep legacy rewrite behavior"
+        );
+
+        let err = Error::new(segment.ident.span(), message);
+        if let Some(existing) = &mut errors {
+            existing.combine(err);
+        } else {
+            errors = Some(err);
+        }
+    }
+
+    match errors {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
+}
+
 fn maybe_rewrite_typed_arg(arg: &mut syn::PatType, server_crate: &syn::Path) -> syn::Result<()> {
     let (kind, original_segment, inner_ty) = match extract_rewrite_target(&arg.ty)? {
         Some(values) => values,
@@ -281,6 +341,13 @@ fn extract_rewrite_target(ty: &Type) -> syn::Result<Option<(ExtractorKind, PathS
     Ok(Some((kind, segment.clone(), inner_ty)))
 }
 
+fn last_type_segment(ty: &Type) -> Option<&PathSegment> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    type_path.path.segments.last()
+}
+
 fn rewrite_pattern(
     pat: &mut Box<Pat>,
     kind: ExtractorKind,
@@ -293,9 +360,11 @@ fn rewrite_pattern(
                 return Err(Error::new(
                     path.span(),
                     format!(
-                        "unsupported `{}` pattern in auto_validate; use `{name}(value)` or `value: {name}<T>`",
+                        "unsupported `{}` pattern in auto_validate; use `{name}(value)` or `value: {name}<T>`. \
+                         for explicit signatures without rewrite, use `#[route(..., auto_validate, transparent)]` with `{validated}<T>`",
                         kind.source_ident(),
-                        name = kind.source_ident()
+                        name = kind.source_ident(),
+                        validated = kind.validated_ident()
                     ),
                 ));
             };
@@ -307,8 +376,11 @@ fn rewrite_pattern(
                 return Err(Error::new(
                     last.ident.span(),
                     format!(
-                        "pattern `{}` does not match extractor `{}` in auto_validate; expected `{}` pattern",
-                        last_name, source, source
+                        "pattern `{}` does not match extractor `{}` in auto_validate; expected `{}` pattern or switch to `transparent` mode with `{}`",
+                        last_name,
+                        source,
+                        source,
+                        kind.validated_ident()
                     ),
                 ));
             }
@@ -321,9 +393,11 @@ fn rewrite_pattern(
                 return Err(Error::new(
                     ident_pat.span(),
                     format!(
-                        "unsupported `{}` binding form in auto_validate; use simple binding like `value: {}<T>`",
+                        "unsupported `{}` binding form in auto_validate; use simple binding like `value: {}<T>` \
+                         or `transparent` mode with `{}`",
                         kind.source_ident(),
-                        kind.source_ident()
+                        kind.source_ident(),
+                        kind.validated_ident()
                     ),
                 ));
             }
@@ -345,11 +419,13 @@ fn rewrite_pattern(
         _ => Err(Error::new(
             pat.span(),
             format!(
-                "unsupported pattern for `{}` in auto_validate; use `{}` destructuring (`{}(value)`) or simple binding (`value: {}<T>`)",
+                "unsupported pattern for `{}` in auto_validate; use `{}` destructuring (`{}(value)`) or simple binding (`value: {}<T>`). \
+                 for no-rewrite signatures use `#[route(..., auto_validate, transparent)]` with `{}`",
                 original_segment.ident,
                 kind.source_ident(),
                 kind.source_ident(),
                 kind.source_ident(),
+                kind.validated_ident(),
             ),
         )),
     }
@@ -395,6 +471,7 @@ mod tests {
         assert_eq!(parsed.method, RouteMethod::Post);
         assert_eq!(parsed.path.value(), "/notes");
         assert!(parsed.auto_validate);
+        assert!(!parsed.transparent);
     }
 
     #[test]
@@ -404,6 +481,26 @@ mod tests {
         assert_eq!(parsed.method, RouteMethod::Get);
         assert_eq!(parsed.path.value(), "/health");
         assert!(!parsed.auto_validate);
+        assert!(!parsed.transparent);
+    }
+
+    #[test]
+    fn parses_transparent_auto_validate_mode() {
+        let parsed = parse_str::<RouteArgs>(r#"post, "/notes", auto_validate, transparent"#)
+            .expect("route args should parse");
+
+        assert_eq!(parsed.method, RouteMethod::Post);
+        assert!(parsed.auto_validate);
+        assert!(parsed.transparent);
+    }
+
+    #[test]
+    fn rejects_transparent_without_auto_validate() {
+        let err = match parse_str::<RouteArgs>(r#"post, "/notes", transparent"#) {
+            Ok(_) => panic!("transparent without auto_validate must fail"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("requires `auto_validate`"));
     }
 
     #[test]
@@ -507,6 +604,31 @@ mod tests {
         let server_crate: syn::Path = parse_quote!(::openportio_server);
         let err = apply_auto_validate(&mut item_fn, &server_crate).expect_err("must fail");
         assert!(err.to_string().contains("unsupported pattern"));
+    }
+
+    #[test]
+    fn transparent_auto_validate_rejects_hidden_rewrite_extractors() {
+        let item_fn: ItemFn = parse_quote! {
+            async fn create_note(Query(q): Query<ListQuery>, Json(body): Json<CreateNote>) {}
+        };
+
+        let err = apply_transparent_auto_validate(&item_fn).expect_err("must fail");
+        let message = err.to_string();
+        assert!(message.contains("does not rewrite extractors"));
+        assert!(message.contains("ValidatedQuery"), "message: {message}");
+    }
+
+    #[test]
+    fn transparent_auto_validate_accepts_explicit_validated_extractors() {
+        let item_fn: ItemFn = parse_quote! {
+            async fn create_note(
+                ::openportio_server::api::ValidatedQuery(query): ::openportio_server::api::ValidatedQuery<ListQuery>,
+                ::openportio_server::api::ValidatedJson(body): ::openportio_server::api::ValidatedJson<CreateNote>
+            ) {}
+        };
+
+        apply_transparent_auto_validate(&item_fn)
+            .expect("explicit validated extractors should pass");
     }
 
     #[test]

--- a/docs/dx-scorecard.md
+++ b/docs/dx-scorecard.md
@@ -122,3 +122,25 @@ For advanced validation logic that cannot be expressed with `validator` attribut
 Result:
 - All-in-one convenience (`#[dto]`) remains intact
 - Advanced teams get trait-first control without abandoning Openportio extractors
+
+## 7) Route Macro Transparency Mode
+
+Openportio route macro now supports explicit no-rewrite mode:
+- `#[route(..., auto_validate)]`: legacy-compatible extractor rewrite
+- `#[route(..., auto_validate, transparent)]`: no hidden rewrite, explicit `Validated*` extractors only
+
+Transparent mode example:
+
+```rust
+#[openportio_server::route(post, "/notes", auto_validate, transparent)]
+async fn create_note(
+    openportio_server::api::ValidatedJson(body): openportio_server::api::ValidatedJson<CreateNoteBody>,
+) -> Result<axum::Json<String>, openportio_server::api::ApiError> {
+    Ok(axum::Json(body.title))
+}
+```
+
+Result:
+- handler signature stays exactly what the author wrote
+- compile diagnostics explain how to migrate when raw `Json/Query/Path` is used with `transparent`
+- existing legacy `auto_validate` flows remain backward compatible

--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -218,7 +218,7 @@ OpenAPI wiring:
 
 For a more FastAPI-like handler style, use `#[openportio_server::route(..., auto_validate)]`.
 
-With `auto_validate`, handler arguments are rewritten at compile time:
+Legacy `auto_validate` rewrites handler arguments at compile time:
 - `Json<T>` -> `ValidatedJson<T>`
 - `Query<T>` -> `ValidatedQuery<T>`
 - `Path<T>` -> `ValidatedPath<T>`
@@ -235,6 +235,23 @@ async fn create_note(Json(body): Json<CreateNoteBody>) -> Result<Json<String>, A
 }
 ```
 
+Transparent mode (recommended for macro transparency):
+
+```rust
+use openportio_server::api::{ApiError, ValidatedJson};
+use axum::Json;
+
+#[openportio_server::route(post, "/notes", auto_validate, transparent)]
+async fn create_note(
+    ValidatedJson(body): ValidatedJson<CreateNoteBody>,
+) -> Result<Json<String>, ApiError> {
+    Ok(Json(body.title))
+}
+```
+
+In `transparent` mode, the macro does not rewrite extractor types.
+If raw `Json<T>/Query<T>/Path<T>` is used, compile-time errors explain how to migrate.
+
 If you omit `auto_validate`, behavior stays unchanged.
 
 For header/cookie wrapper patterns, use `ValidatedParts<T>` with your custom parts extractor
@@ -243,6 +260,12 @@ that implements `Validate`.
 Macro portability:
 - `#[route(...)]` expansion is dependency-rename safe.
 - Example compile coverage exists under `examples/openportio-app`.
+- Legacy compatibility: existing `auto_validate` rewrite behavior is still supported.
+
+Debugging guidance:
+- use `cargo expand -p <crate> --bin <target>` to inspect route macro expansion.
+- prefer `transparent` mode for production handlers where explicit signatures are important.
+- when compile errors mention extractor migration, replace raw extractors with explicit validated extractors first.
 
 ## SSE Endpoint Pattern
 

--- a/examples/openportio-app/src/main.rs
+++ b/examples/openportio-app/src/main.rs
@@ -1,4 +1,5 @@
 use axum::{Json, Router};
+use openportio::api::{ValidatedJson, ValidatedPath};
 use openportio::prelude::*;
 
 #[openportio::dto]
@@ -13,15 +14,15 @@ struct ItemPath {
     id: String,
 }
 
-#[openportio::route(post, "/payload", auto_validate)]
-async fn create_payload(Json(payload): Json<Payload>) -> Result<Json<String>, ApiError> {
+#[openportio::route(post, "/payload", auto_validate, transparent)]
+async fn create_payload(
+    ValidatedJson(payload): ValidatedJson<Payload>,
+) -> Result<Json<String>, ApiError> {
     Ok(Json(payload.name))
 }
 
-#[openportio::route(get, "/items/:id", auto_validate)]
-async fn get_item(
-    axum::extract::Path(path): axum::extract::Path<ItemPath>,
-) -> Result<Json<String>, ApiError> {
+#[openportio::route(get, "/items/:id", auto_validate, transparent)]
+async fn get_item(ValidatedPath(path): ValidatedPath<ItemPath>) -> Result<Json<String>, ApiError> {
     Ok(Json(path.id))
 }
 

--- a/examples/production-api/src/main.rs
+++ b/examples/production-api/src/main.rs
@@ -10,7 +10,7 @@ use axum::{
 use chrono::{DateTime, Utc};
 use openportio_core::{auth::AuthPrincipal, AppState};
 use openportio_server::{
-    api::{ApiError, ApiErrorResponse},
+    api::{ApiError, ApiErrorResponse, ValidatedJson, ValidatedPath, ValidatedQuery},
     auth::{self, AuthRuntimeConfig},
     OpenportioServer,
 };
@@ -230,11 +230,11 @@ async fn readyz(
     }))
 }
 
-#[openportio_server::route(post, "/v1/notes", auto_validate)]
+#[openportio_server::route(post, "/v1/notes", auto_validate, transparent)]
 async fn create_note(
     Extension(principal): Extension<AuthPrincipal>,
     State(state): State<Arc<ProductionApiState>>,
-    Json(body): Json<CreateNoteBody>,
+    ValidatedJson(body): ValidatedJson<CreateNoteBody>,
 ) -> Result<(StatusCode, Json<NoteResponse>), ApiError> {
     let note = sqlx::query_as::<_, NoteRow>(
         r#"
@@ -257,11 +257,11 @@ async fn create_note(
     Ok((StatusCode::CREATED, Json(note.into_response())))
 }
 
-#[openportio_server::route(get, "/v1/notes", auto_validate)]
+#[openportio_server::route(get, "/v1/notes", auto_validate, transparent)]
 async fn list_notes(
     Extension(principal): Extension<AuthPrincipal>,
     State(state): State<Arc<ProductionApiState>>,
-    axum::extract::Query(query): axum::extract::Query<ListNotesQuery>,
+    ValidatedQuery(query): ValidatedQuery<ListNotesQuery>,
 ) -> Result<Json<Vec<NoteResponse>>, ApiError> {
     let limit = query.limit.unwrap_or(20);
 
@@ -292,11 +292,11 @@ async fn list_notes(
     ))
 }
 
-#[openportio_server::route(get, "/protected/notes/:id", auto_validate)]
+#[openportio_server::route(get, "/protected/notes/:id", auto_validate, transparent)]
 async fn get_protected_note(
     Extension(principal): Extension<AuthPrincipal>,
     State(state): State<Arc<ProductionApiState>>,
-    axum::extract::Path(path): axum::extract::Path<NotePath>,
+    ValidatedPath(path): ValidatedPath<NotePath>,
 ) -> Result<Json<ProtectedNoteResponse>, ApiError> {
     let subject = principal.subject;
     let maybe_note = sqlx::query_as::<_, NoteRow>(

--- a/examples/simple-server/src/main.rs
+++ b/examples/simple-server/src/main.rs
@@ -10,7 +10,7 @@ use axum::{
 };
 use openportio_core::AppState;
 use openportio_server::{
-    api::{bad_request, ApiError},
+    api::{bad_request, ApiError, ValidatedJson, ValidatedPath, ValidatedQuery},
     di::Depends,
     OpenportioServer,
 };
@@ -93,12 +93,12 @@ where
     }
 }
 
-#[openportio_server::route(get, "/notes/:id", auto_validate)]
+#[openportio_server::route(get, "/notes/:id", auto_validate, transparent)]
 async fn get_note(
     ctx: RequestContext,
     Depends(service): Depends<ServiceInfo>,
     State(state): State<Arc<AppState>>,
-    axum::extract::Path(path): axum::extract::Path<NotePath>,
+    ValidatedPath(path): ValidatedPath<NotePath>,
 ) -> Result<Json<NoteResponse>, ApiError> {
     let title = state
         .greet(&path.id)
@@ -111,21 +111,19 @@ async fn get_note(
     }))
 }
 
-#[openportio_server::route(get, "/notes", auto_validate)]
-async fn list_notes(
-    axum::extract::Query(query): axum::extract::Query<NoteQuery>,
-) -> Json<NotesListResponse> {
+#[openportio_server::route(get, "/notes", auto_validate, transparent)]
+async fn list_notes(ValidatedQuery(query): ValidatedQuery<NoteQuery>) -> Json<NotesListResponse> {
     Json(NotesListResponse {
         query: query.q,
         limit: query.limit.unwrap_or(20),
     })
 }
 
-#[openportio_server::route(post, "/notes", auto_validate)]
+#[openportio_server::route(post, "/notes", auto_validate, transparent)]
 async fn create_note(
     ctx: RequestContext,
     Depends(service): Depends<ServiceInfo>,
-    Json(body): Json<CreateNoteBody>,
+    ValidatedJson(body): ValidatedJson<CreateNoteBody>,
 ) -> Json<NoteResponse> {
     Json(NoteResponse {
         id: "note-1".to_string(),


### PR DESCRIPTION
## Summary
- add `transparent` mode to `#[route(...)]` flag parsing for `auto_validate` handlers
- keep legacy `auto_validate` rewrite behavior fully backward-compatible
- in `transparent` mode, reject raw `Json/Query/Path` extractors with actionable compile-time migration guidance to `Validated*`
- improve diagnostics for unsupported flag usage and auto-validate rewrite pattern errors
- migrate framework examples to explicit `Validated*` signatures with `auto_validate, transparent`
- document macro transparency modes, compatibility notes, and debugging workflow (`cargo expand` guidance)

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p openportio-macros`
- `cargo test -p openportio-app`
- `cargo test -p simple-server`
- `cargo test -p production-api`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #93
