### PR TITLE
feat(di): add typed required dependency guards (#94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Recommended audience paths:
   - implement `openportio_server::api::RequestValidation` for advanced custom checks
 - Depends-style DI extractor with request cache:
   - `openportio_server::di::Depends<T>`
+- Typed required-dependency guard for critical paths:
+  - `OpenportioServer::require_dependency::<T>().with_dependency(value)`
+  - keep `with_dependency(value)` for optional/test override ergonomics
 - Shared middleware stack:
   - tracing, request-id propagation, CORS, timeout, concurrency limit
 - Declarative domain error mapping policy:

--- a/crates/openportio-server/src/builder.rs
+++ b/crates/openportio-server/src/builder.rs
@@ -349,9 +349,8 @@ impl<T> RequiredDependencyBuilder<T>
 where
     T: Clone + Send + Sync + 'static,
 {
-    pub fn with_dependency(mut self, value: T) -> OpenportioServer {
-        self.server.dependency_overrides = self.server.dependency_overrides.with(value);
-        self.server
+    pub fn with_dependency(self, value: T) -> OpenportioServer {
+        self.server.with_dependency(value)
     }
 }
 

--- a/crates/openportio-server/src/builder.rs
+++ b/crates/openportio-server/src/builder.rs
@@ -1,4 +1,7 @@
-use std::{convert::Infallible, env, future::IntoFuture, io, net::SocketAddr, sync::Arc};
+use std::{
+    convert::Infallible, env, future::IntoFuture, io, marker::PhantomData, net::SocketAddr,
+    sync::Arc,
+};
 
 use axum::Router;
 use http::{Request, Response};
@@ -27,6 +30,11 @@ pub struct OpenportioServer {
     middleware_customizers: Vec<RouterCustomizer>,
     startup_hooks: Vec<StartupHook>,
     shutdown_hooks: Vec<ShutdownHook>,
+}
+
+pub struct RequiredDependencyBuilder<T> {
+    server: OpenportioServer,
+    _marker: PhantomData<T>,
 }
 
 impl OpenportioServer {
@@ -78,6 +86,37 @@ impl OpenportioServer {
     pub fn merge_raw_router(mut self, router: Router) -> Self {
         self.raw_routers.push(router);
         self
+    }
+
+    /// Enter a typed required-dependency binding flow.
+    ///
+    /// This guard forces the dependency value to be bound before app build/run APIs are
+    /// reachable again.
+    ///
+    /// ```compile_fail
+    /// use openportio_server::OpenportioServer;
+    ///
+    /// let _app = OpenportioServer::new()
+    ///     .require_dependency::<String>()
+    ///     .build_app();
+    /// ```
+    ///
+    /// ```rust
+    /// use openportio_server::OpenportioServer;
+    ///
+    /// let _app = OpenportioServer::new()
+    ///     .require_dependency::<String>()
+    ///     .with_dependency("ready".to_string())
+    ///     .build_app();
+    /// ```
+    pub fn require_dependency<T>(self) -> RequiredDependencyBuilder<T>
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        RequiredDependencyBuilder {
+            server: self,
+            _marker: PhantomData,
+        }
     }
 
     pub fn with_dependency<T>(mut self, value: T) -> Self
@@ -306,6 +345,16 @@ impl OpenportioServer {
     }
 }
 
+impl<T> RequiredDependencyBuilder<T>
+where
+    T: Clone + Send + Sync + 'static,
+{
+    pub fn with_dependency(mut self, value: T) -> OpenportioServer {
+        self.server.dependency_overrides = self.server.dependency_overrides.with(value);
+        self.server
+    }
+}
+
 impl Default for OpenportioServer {
     fn default() -> Self {
         Self::new()
@@ -490,6 +539,33 @@ mod tests {
             .await
             .expect("response body");
         assert_eq!(String::from_utf8(body.to_vec()).expect("utf8"), "override");
+    }
+
+    #[tokio::test]
+    async fn builder_requires_typed_dependency_binding_before_build() {
+        let app = OpenportioServer::new()
+            .without_grpc()
+            .with_rest_router(
+                Router::new()
+                    .route("/dep", get(dep_handler))
+                    .with_state(Arc::new(AppState::local("builder-required-test"))),
+            )
+            .require_dependency::<LabelDep>()
+            .with_dependency(LabelDep("required-override".to_string()))
+            .build_app();
+
+        let response = app
+            .oneshot(Request::builder().uri("/dep").body(Body::empty()).unwrap())
+            .await
+            .expect("dep request should succeed");
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("response body");
+        assert_eq!(
+            String::from_utf8(body.to_vec()).expect("utf8"),
+            "required-override"
+        );
     }
 
     #[test]

--- a/docs/dx-scorecard.md
+++ b/docs/dx-scorecard.md
@@ -61,11 +61,13 @@ Result:
 
 Added provider-style override utilities:
 - `OpenportioServer::with_dependency(value)`
+- `OpenportioServer::require_dependency::<T>().with_dependency(value)`
 - `openportio_server::di::with_dependency(...)`
 - `openportio_server::di::with_dependency_overrides(...)`
 
 Result:
 - Cleaner test-time wiring for multiple dependencies
+- Compile-time guarded binding for critical dependency paths
 - Request-scoped dependency caching still guaranteed
 
 ## 5) Error Mapping Policy

--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -383,6 +383,28 @@ Test override helper:
 - `openportio_server::di::with_dependency_overrides(router, overrides)`
 - `OpenportioServer::with_dependency(value)`
 
+Required-vs-optional strategy:
+- optional/test dependencies: keep using `with_dependency(...)` (runtime override ergonomics)
+- critical dependencies: use typed guard flow `require_dependency::<T>().with_dependency(...)`
+  so the builder cannot reach `build_app()`/`run()` until that dependency is provided
+
+Typed required dependency example:
+
+```rust
+use openportio_server::OpenportioServer;
+
+let app = OpenportioServer::new()
+    .require_dependency::<String>()
+    .with_dependency("critical-service".to_string())
+    .build_app();
+```
+
+Migration note:
+- existing `with_dependency(...)` call sites remain valid
+- upgrade critical paths incrementally by replacing:
+  - `with_dependency(value)`
+  - with `require_dependency::<Type>().with_dependency(value)` where compile-time binding is desired
+
 ## Notes
 
 - Default `OpenportioServer::new()` enables both REST and gRPC on a single listener.


### PR DESCRIPTION
## Summary
- add typed required-dependency guard flow to the builder API via `require_dependency::<T>().with_dependency(...)`
- keep existing runtime override ergonomics (`with_dependency`, `with_dependency_overrides`) unchanged for optional/test composition
- document required-vs-optional DI strategy and migration notes

## What Changed
- `crates/openportio-server/src/builder.rs`
  - added `RequiredDependencyBuilder<T>`
  - added `OpenportioServer::require_dependency::<T>()` typed guard entrypoint
  - added compile-fail + compile-pass doc tests for required binding flow
  - added runtime test: `builder_requires_typed_dependency_binding_before_build`
- docs
  - updated `docs/fastapi-like-builder.md` with required/optional DI strategy + migration guidance
  - updated `docs/dx-scorecard.md` DI section to include compile-time guard path
  - updated root `README.md` feature bullets for typed required dependencies

## Acceptance Criteria Mapping (#94)
- Required dependency contracts enforced at compile/build time where designed:
  - compile-fail doctest verifies build cannot proceed after `require_dependency::<T>()` until typed `with_dependency(...)` is provided
- Existing override ergonomics remain usable:
  - `with_dependency(...)` and existing override helpers are unchanged
- Documentation explains required vs optional strategy:
  - included in builder docs + README + DX scorecard
- Tests validate strict and flexible DI modes:
  - strict: new typed-guard runtime test + compile-fail doc test
  - flexible: existing dependency override tests preserved and passing

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p openportio-server`
- `cargo clippy -p openportio-server --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #94
