### PR TITLE
feat(ci): add REST+gRPC contract compatibility gate (#87)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,36 @@ jobs:
       - name: Verify OpenAPI route test
         run: cargo test -p openportio-server openapi_json_is_available -- --nocapture
 
+  contract-compat:
+    name: Contract Compatibility Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Fetch PR base branch ref
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+
+      - name: Run REST+gRPC contract compatibility gate
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            export OPENPORTIO_CONTRACT_COMPAT_BASE_REF="origin/${GITHUB_BASE_REF}"
+          else
+            export OPENPORTIO_CONTRACT_COMPAT_BASE_REF="origin/develop"
+          fi
+          ./scripts/check_contract_compatibility.sh
+
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -426,6 +426,12 @@ Check drift (used in CI):
 ./scripts/check_contracts_bundle.sh
 ```
 
+Check backward compatibility against base branch contracts:
+
+```bash
+./scripts/check_contract_compatibility.sh
+```
+
 This generates:
 - `contracts/links.toml` (explicit REST <-> gRPC mapping source)
 - `docs/generated/rest-openapi.json`
@@ -446,6 +452,7 @@ This runs:
 - `cargo test --workspace`
 - REST+gRPC multiplexing integration test
 - contract artifact drift check
+- contract compatibility gate (base-ref diff)
 - OpenAPI route check
 - production preflight gate
 
@@ -479,6 +486,9 @@ Use this index for fast incident routing:
 - Contracts/OpenAPI drift failures:
   - `docs/ci-workflow.md`
   - `scripts/check_contracts_bundle.sh`
+- Contract compatibility gate failures:
+  - `docs/contracts-compatibility.md`
+  - `scripts/check_contract_compatibility.sh`
 - Docs-site pipeline failures:
   - `docs/release/docs-site-runbook.md`
 - Release dry-run/publish failures:

--- a/contracts/compat_exceptions.toml
+++ b/contracts/compat_exceptions.toml
@@ -1,0 +1,9 @@
+version = 1
+
+# Temporary compatibility waivers for intentional breaking changes.
+# Keep this file empty by default. Add an entry only when a break is deliberate.
+#
+# [[exceptions]]
+# id = "rest.operation.removed:hello"
+# reason = "Intentional cleanup for v0.2; migration plan in issue #123."
+# expires_on = "2026-12-31"

--- a/docs/adr/0001-contract-ssot.md
+++ b/docs/adr/0001-contract-ssot.md
@@ -53,7 +53,9 @@ REST-only payloads can remain local Rust DTOs when they are not part of the shar
 
 - Any change to proto or contract-generation logic must keep generated artifacts up to date.
 - PRs that introduce artifact drift are blocked by CI.
-- Breaking-change policy enforcement is handled by dedicated compatibility gate work (see follow-ups).
+- PRs that introduce backward-incompatible contract changes are blocked by the compatibility gate:
+  - `./scripts/check_contract_compatibility.sh`
+  - policy: `docs/contracts-compatibility.md`
 
 ## Migration Impact
 
@@ -102,4 +104,3 @@ Trade-offs:
 - #92: observability defaults with optional OTel export
 - #93: macro transparency and debug ergonomics
 - #94: typed required-dependency guards for DI
-- #87: explicit breaking-change compatibility gate in CI

--- a/docs/ci-workflow.md
+++ b/docs/ci-workflow.md
@@ -22,22 +22,27 @@ This project uses focused CI jobs so failures are clearly scoped:
 - `./scripts/check_contracts_bundle.sh`
 - `cargo test -p openportio-server openapi_json_is_available -- --nocapture`
 
-6. `Security Audit`
+6. `Contract Compatibility Gate`
+- `./scripts/check_contract_compatibility.sh`
+- compares current `docs/generated/contracts-bundle.json` with base branch bundle
+- fails on backward-incompatible REST/gRPC contract changes
+
+7. `Security Audit`
 - `cargo audit`
 
-7. `Production Preflight`
+8. `Production Preflight`
 - `./scripts/prod_preflight.sh` with secure-mode CI environment
 
-8. `Release Dry Run`
+9. `Release Dry Run`
 - `./scripts/release_dry_run.sh`
 
-9. `Perf Regression Gate` (manual workflow)
+10. `Perf Regression Gate` (manual workflow)
 - workflow: `.github/workflows/perf.yml`
 - trigger: `workflow_dispatch`
 - runs REST (`k6`) + gRPC (`ghz`) perf smoke with threshold enforcement
 - uploads artifact: `perf-report`
 
-10. `Docs Site`
+11. `Docs Site`
 - workflow: `.github/workflows/docs-site.yml`
 - validates docs links, builds VitePress, verifies `sitemap.xml` + `robots.txt`, deploys GitHub Pages, then runs post-deploy smoke check
 

--- a/docs/contracts-compatibility.md
+++ b/docs/contracts-compatibility.md
@@ -1,0 +1,73 @@
+# Contract Compatibility Policy
+
+Openportio uses a contract compatibility gate in PR CI to block backward-incompatible REST/gRPC changes before merge.
+
+## Scope
+
+Compatibility is checked against the target base branch contract bundle (`docs/generated/contracts-bundle.json`).
+
+Gate command:
+
+```bash
+./scripts/check_contract_compatibility.sh
+```
+
+Core checker:
+
+```bash
+python3 scripts/check_contract_compatibility.py --base-ref origin/develop
+```
+
+## What Is Considered Breaking
+
+The current gate treats the following as breaking:
+
+- REST operation removal:
+  - `rest.operation.removed:<operation_id>`
+- REST operation signature change (method/path changed for same `operation_id`):
+  - `rest.operation.signature_changed:<operation_id>`
+- gRPC method removal:
+  - `grpc.method.removed:<package.Service/Method>`
+- gRPC method shape change in generated bridge contract:
+  - `grpc.method.shape_changed:<package.Service/Method>`
+  - checked fields: `http_method`, `path`, `request_schema_ref`, `response_schema_ref`
+- REST<->gRPC contract mapping link removal:
+  - `contracts.link.removed:<rest_operation_id>-><grpc_method>`
+
+These are conservative-by-default because they can break existing clients and integration contracts.
+
+## Non-Breaking (Examples)
+
+- adding a new REST operation
+- adding a new gRPC method
+- adding metadata/docs fields without changing existing method/path/schema references
+
+## Intentional Breaks: Controlled Waiver Process
+
+When a break is intentional, add a temporary waiver in:
+
+- `contracts/compat_exceptions.toml`
+
+Template:
+
+```toml
+[[exceptions]]
+id = "rest.operation.removed:hello"
+reason = "Intentional removal tracked in issue #123 with migration notes."
+expires_on = "2026-12-31"
+```
+
+Rules:
+
+- `id` must exactly match CI output.
+- `reason` is required and should reference migration context (issue/PR/runbook).
+- `expires_on` is optional but recommended.
+- expired waivers are treated as failures.
+
+The checker prints unused waivers as warnings so stale exceptions can be removed.
+
+## CI Wiring
+
+- Workflow: `.github/workflows/ci.yml`
+- Required PR job: `Contract Compatibility Gate`
+- The job fetches the PR base branch and compares current bundle against that baseline.

--- a/docs/grpc-contract-docs-strategy.md
+++ b/docs/grpc-contract-docs-strategy.md
@@ -35,11 +35,13 @@ Why this choice:
 - Generator: `scripts/generate_grpc_contract_docs.sh` (calls `cargo run -p openportio-rpc --bin grpc-docgen`)
 - Bundled generator flow: `scripts/generate_contracts_bundle.sh`
 - Drift check used in CI: `scripts/check_contracts_bundle.sh`
+- Compatibility gate used in PR CI: `scripts/check_contract_compatibility.sh`
 
 Reproducible flow:
 1. Run `./scripts/generate_contracts_bundle.sh`
 2. Commit updated artifacts under `docs/generated/`
 3. In CI, run `scripts/check_contracts_bundle.sh` and fail on drift
+4. In PR CI, run `scripts/check_contract_compatibility.sh` and fail on breaking changes
 
 ## Published Paths
 

--- a/docs/release/versioning.md
+++ b/docs/release/versioning.md
@@ -16,6 +16,18 @@ Openportio follows an initial `0.y.z` policy until first stable `1.0.0`.
 - `z` (patch): backward-compatible fixes/docs/internal changes
 - `y` (minor): backward-incompatible API changes or major feature milestones during `0.x`
 
+## Contract Compatibility Gate
+
+PR CI enforces contract compatibility before merge:
+
+- gate command: `./scripts/check_contract_compatibility.sh`
+- baseline: target base branch `docs/generated/contracts-bundle.json`
+- policy and waiver process: `docs/contracts-compatibility.md`
+
+Intentional breaking changes must be explicitly waived with a temporary, reasoned entry in:
+
+- `contracts/compat_exceptions.toml`
+
 ## Release Notes Expectations
 
 Each release should include:

--- a/scripts/check_contract_compatibility.py
+++ b/scripts/check_contract_compatibility.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Check REST+gRPC contract compatibility against a base git ref."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - fallback for older local Python
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+@dataclass(frozen=True)
+class BreakingChange:
+    change_id: str
+    message: str
+    why_breaking: str
+
+
+@dataclass(frozen=True)
+class Waiver:
+    change_id: str
+    reason: str
+    expires_on: dt.date | None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare docs/generated/contracts-bundle.json against a base git ref and fail on "
+            "backward-incompatible REST/gRPC contract changes."
+        )
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="origin/develop",
+        help="Git ref used as compatibility baseline (default: origin/develop)",
+    )
+    parser.add_argument(
+        "--head-bundle",
+        default="docs/generated/contracts-bundle.json",
+        help="Bundle path for current branch (repo-relative)",
+    )
+    parser.add_argument(
+        "--base-bundle",
+        default="docs/generated/contracts-bundle.json",
+        help="Bundle path read from base ref via git show (repo-relative)",
+    )
+    parser.add_argument(
+        "--exceptions",
+        default="contracts/compat_exceptions.toml",
+        help="Compatibility waiver config path (repo-relative)",
+    )
+    return parser.parse_args()
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def ensure_repo_relative_path(raw: str, root: Path, *, arg_name: str) -> Path:
+    path = Path(raw)
+    if path.is_absolute():
+        raise ValueError(f"{arg_name} must be a repository-relative path, got absolute path")
+
+    resolved = (root / path).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError(f"{arg_name} escapes repository root: {raw}") from exc
+    return resolved
+
+
+def load_json_file(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must be a JSON object")
+    return payload
+
+
+def load_json_from_git(base_ref: str, repo_relative_path: str) -> dict[str, Any]:
+    git_path = f"{base_ref}:{repo_relative_path}"
+    process = subprocess.run(
+        ["git", "show", git_path],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if process.returncode != 0:
+        stderr = process.stderr.strip() or "unknown git show error"
+        raise RuntimeError(
+            f"failed to read `{repo_relative_path}` from `{base_ref}` via git show: {stderr}"
+        )
+    try:
+        payload = json.loads(process.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"{repo_relative_path} at {base_ref} is not valid JSON: {exc}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"{repo_relative_path} at {base_ref} must be a JSON object")
+    return payload
+
+
+def rest_operations(bundle: dict[str, Any]) -> dict[str, dict[str, str]]:
+    rest = bundle.get("rest")
+    if not isinstance(rest, dict):
+        raise ValueError("bundle is missing object field: rest")
+
+    operations = rest.get("operations")
+    if not isinstance(operations, list):
+        raise ValueError("bundle is missing list field: rest.operations")
+
+    result: dict[str, dict[str, str]] = {}
+    for index, operation in enumerate(operations):
+        if not isinstance(operation, dict):
+            raise ValueError(f"rest.operations[{index}] must be an object")
+        operation_id = operation.get("operation_id")
+        method = operation.get("method")
+        path = operation.get("path")
+        if not isinstance(operation_id, str) or not operation_id:
+            raise ValueError(f"rest.operations[{index}] has invalid operation_id")
+        if not isinstance(method, str) or not method:
+            raise ValueError(f"rest.operations[{index}] has invalid method")
+        if not isinstance(path, str) or not path:
+            raise ValueError(f"rest.operations[{index}] has invalid path")
+        if operation_id in result:
+            raise ValueError(f"duplicate rest operation_id in bundle: {operation_id}")
+        result[operation_id] = {"method": method, "path": path}
+    return result
+
+
+def grpc_methods(bundle: dict[str, Any]) -> dict[str, dict[str, str | None]]:
+    grpc = bundle.get("grpc")
+    if not isinstance(grpc, dict):
+        raise ValueError("bundle is missing object field: grpc")
+
+    methods = grpc.get("methods")
+    if not isinstance(methods, list):
+        raise ValueError("bundle is missing list field: grpc.methods")
+
+    result: dict[str, dict[str, str | None]] = {}
+    for index, method_entry in enumerate(methods):
+        if not isinstance(method_entry, dict):
+            raise ValueError(f"grpc.methods[{index}] must be an object")
+        method = method_entry.get("grpc_method")
+        if not isinstance(method, str) or not method:
+            raise ValueError(f"grpc.methods[{index}] has invalid grpc_method")
+        if method in result:
+            raise ValueError(f"duplicate grpc method in bundle: {method}")
+        result[method] = {
+            "http_method": as_opt_string(method_entry.get("http_method")),
+            "path": as_opt_string(method_entry.get("path")),
+            "request_schema_ref": as_opt_string(method_entry.get("request_schema_ref")),
+            "response_schema_ref": as_opt_string(method_entry.get("response_schema_ref")),
+        }
+    return result
+
+
+def contract_links(bundle: dict[str, Any]) -> set[tuple[str, str]]:
+    links = bundle.get("links")
+    if not isinstance(links, list):
+        raise ValueError("bundle is missing list field: links")
+
+    result: set[tuple[str, str]] = set()
+    for index, link in enumerate(links):
+        if not isinstance(link, dict):
+            raise ValueError(f"links[{index}] must be an object")
+        rest_operation_id = link.get("rest_operation_id")
+        grpc_method = link.get("grpc_method")
+        if not isinstance(rest_operation_id, str) or not rest_operation_id:
+            raise ValueError(f"links[{index}] has invalid rest_operation_id")
+        if not isinstance(grpc_method, str) or not grpc_method:
+            raise ValueError(f"links[{index}] has invalid grpc_method")
+        result.add((rest_operation_id, grpc_method))
+    return result
+
+
+def as_opt_string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def compare_rest(
+    base_ops: dict[str, dict[str, str]], head_ops: dict[str, dict[str, str]]
+) -> list[BreakingChange]:
+    changes: list[BreakingChange] = []
+
+    removed_ids = sorted(set(base_ops) - set(head_ops))
+    for operation_id in removed_ids:
+        old = base_ops[operation_id]
+        changes.append(
+            BreakingChange(
+                change_id=f"rest.operation.removed:{operation_id}",
+                message=(
+                    f"REST operation `{operation_id}` was removed "
+                    f"({old['method']} {old['path']})."
+                ),
+                why_breaking=(
+                    "Existing REST clients that call this operation can fail immediately."
+                ),
+            )
+        )
+
+    shared_ids = sorted(set(base_ops) & set(head_ops))
+    for operation_id in shared_ids:
+        old = base_ops[operation_id]
+        new = head_ops[operation_id]
+        diffs: list[str] = []
+        if old["method"] != new["method"]:
+            diffs.append(f"method `{old['method']}` -> `{new['method']}`")
+        if old["path"] != new["path"]:
+            diffs.append(f"path `{old['path']}` -> `{new['path']}`")
+        if diffs:
+            changes.append(
+                BreakingChange(
+                    change_id=f"rest.operation.signature_changed:{operation_id}",
+                    message=(
+                        f"REST operation `{operation_id}` changed signature: "
+                        + ", ".join(diffs)
+                    ),
+                    why_breaking=(
+                        "Clients generated or implemented against the previous route contract "
+                        "may no longer interoperate."
+                    ),
+                )
+            )
+
+    return changes
+
+
+def compare_grpc(
+    base_methods: dict[str, dict[str, str | None]],
+    head_methods: dict[str, dict[str, str | None]],
+) -> list[BreakingChange]:
+    changes: list[BreakingChange] = []
+
+    removed = sorted(set(base_methods) - set(head_methods))
+    for method in removed:
+        old = base_methods[method]
+        changes.append(
+            BreakingChange(
+                change_id=f"grpc.method.removed:{method}",
+                message=(
+                    f"gRPC method `{method}` was removed "
+                    f"({old['http_method']} {old['path']})."
+                ),
+                why_breaking=(
+                    "gRPC clients compiled against the previous service definition can fail with "
+                    "UNIMPLEMENTED or routing errors."
+                ),
+            )
+        )
+
+    shared = sorted(set(base_methods) & set(head_methods))
+    for method in shared:
+        old = base_methods[method]
+        new = head_methods[method]
+        changed_fields: list[str] = []
+        for field in (
+            "http_method",
+            "path",
+            "request_schema_ref",
+            "response_schema_ref",
+        ):
+            if old[field] != new[field]:
+                changed_fields.append(f"{field}: `{old[field]}` -> `{new[field]}`")
+        if changed_fields:
+            changes.append(
+                BreakingChange(
+                    change_id=f"grpc.method.shape_changed:{method}",
+                    message=(
+                        f"gRPC method `{method}` changed bridge shape: "
+                        + ", ".join(changed_fields)
+                    ),
+                    why_breaking=(
+                        "Request/response wire contract changes can break existing gRPC clients "
+                        "and generated SDK assumptions."
+                    ),
+                )
+            )
+
+    return changes
+
+
+def compare_links(
+    base_links: set[tuple[str, str]], head_links: set[tuple[str, str]]
+) -> list[BreakingChange]:
+    changes: list[BreakingChange] = []
+    removed_links = sorted(base_links - head_links)
+    for rest_operation_id, grpc_method in removed_links:
+        changes.append(
+            BreakingChange(
+                change_id=f"contracts.link.removed:{rest_operation_id}->{grpc_method}",
+                message=(
+                    "REST<->gRPC mapping link was removed: "
+                    f"`{rest_operation_id}` -> `{grpc_method}`."
+                ),
+                why_breaking=(
+                    "Contract consumers relying on unified mapping/discovery can lose a previously "
+                    "supported interoperability path."
+                ),
+            )
+        )
+    return changes
+
+
+def parse_waivers(path: Path) -> dict[str, Waiver]:
+    if not path.exists():
+        return {}
+
+    with path.open("rb") as handle:
+        payload = tomllib.load(handle)
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must be a TOML table")
+
+    raw_exceptions = payload.get("exceptions", [])
+    if not isinstance(raw_exceptions, list):
+        raise ValueError(f"{path}: `exceptions` must be an array of tables")
+
+    waivers: dict[str, Waiver] = {}
+    for index, raw in enumerate(raw_exceptions):
+        if not isinstance(raw, dict):
+            raise ValueError(f"{path}: exceptions[{index}] must be a table")
+
+        change_id = raw.get("id")
+        reason = raw.get("reason")
+        raw_expires_on = raw.get("expires_on")
+
+        if not isinstance(change_id, str) or not change_id:
+            raise ValueError(f"{path}: exceptions[{index}].id must be a non-empty string")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError(
+                f"{path}: exceptions[{index}].reason must be a non-empty string"
+            )
+
+        expires_on: dt.date | None = None
+        if raw_expires_on is not None:
+            if not isinstance(raw_expires_on, str):
+                raise ValueError(
+                    f"{path}: exceptions[{index}].expires_on must be YYYY-MM-DD string"
+                )
+            try:
+                expires_on = dt.date.fromisoformat(raw_expires_on)
+            except ValueError as exc:
+                raise ValueError(
+                    f"{path}: exceptions[{index}].expires_on must be YYYY-MM-DD"
+                ) from exc
+
+        if change_id in waivers:
+            raise ValueError(f"{path}: duplicate waiver id `{change_id}`")
+
+        waivers[change_id] = Waiver(
+            change_id=change_id, reason=reason.strip(), expires_on=expires_on
+        )
+    return waivers
+
+
+def print_breaking(changes: list[BreakingChange], waivers: dict[str, Waiver]) -> int:
+    today = dt.date.today()
+    active_ids: set[str] = set()
+    unwaived: list[BreakingChange] = []
+
+    for change in changes:
+        waiver = waivers.get(change.change_id)
+        if waiver is None:
+            print(f"[BREAKING] {change.change_id}")
+            print(f"  - {change.message}")
+            print(f"  - Why: {change.why_breaking}")
+            unwaived.append(change)
+            continue
+
+        if waiver.expires_on is not None and waiver.expires_on < today:
+            print(f"[BREAKING][EXPIRED WAIVER] {change.change_id}")
+            print(f"  - {change.message}")
+            print(f"  - Why: {change.why_breaking}")
+            print(
+                "  - Waiver expired on "
+                f"{waiver.expires_on.isoformat()}: {waiver.reason}"
+            )
+            unwaived.append(change)
+            continue
+
+        active_ids.add(change.change_id)
+        expiry_text = waiver.expires_on.isoformat() if waiver.expires_on else "none"
+        print(f"[WAIVED] {change.change_id}")
+        print(f"  - {change.message}")
+        print(f"  - Waiver reason: {waiver.reason}")
+        print(f"  - Waiver expires_on: {expiry_text}")
+
+    stale_waivers = sorted(set(waivers) - active_ids)
+    for waiver_id in stale_waivers:
+        waiver = waivers[waiver_id]
+        expiry_text = waiver.expires_on.isoformat() if waiver.expires_on else "none"
+        print(
+            "[WARN] unused waiver entry: "
+            f"{waiver_id} (reason={waiver.reason}, expires_on={expiry_text})"
+        )
+
+    return 1 if unwaived else 0
+
+
+def main() -> int:
+    args = parse_args()
+    root = repo_root()
+
+    head_bundle_path = ensure_repo_relative_path(
+        args.head_bundle, root, arg_name="--head-bundle"
+    )
+    base_bundle_path = ensure_repo_relative_path(
+        args.base_bundle, root, arg_name="--base-bundle"
+    )
+    exceptions_path = ensure_repo_relative_path(
+        args.exceptions, root, arg_name="--exceptions"
+    )
+
+    if not head_bundle_path.exists():
+        raise RuntimeError(
+            f"head bundle does not exist: {head_bundle_path} "
+            "(run ./scripts/generate_contracts_bundle.sh first)"
+        )
+
+    head_bundle = load_json_file(head_bundle_path)
+    base_bundle = load_json_from_git(
+        args.base_ref,
+        str(base_bundle_path.relative_to(root).as_posix()),
+    )
+    waivers = parse_waivers(exceptions_path)
+
+    changes: list[BreakingChange] = []
+    changes.extend(compare_rest(rest_operations(base_bundle), rest_operations(head_bundle)))
+    changes.extend(compare_grpc(grpc_methods(base_bundle), grpc_methods(head_bundle)))
+    changes.extend(compare_links(contract_links(base_bundle), contract_links(head_bundle)))
+
+    if not changes:
+        print(
+            f"[PASS] No breaking contract changes detected against `{args.base_ref}` "
+            f"using `{base_bundle_path.relative_to(root)}`."
+        )
+        if waivers:
+            unused = ", ".join(sorted(waivers))
+            print(f"[WARN] waiver file has entries but no current breakages: {unused}")
+        return 0
+
+    print(f"Detected {len(changes)} potential breaking contract change(s).")
+    print(
+        "If a break is intentional, add a temporary waiver entry to "
+        "`contracts/compat_exceptions.toml` with reason and expires_on."
+    )
+    return print_breaking(changes, waivers)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as err:  # pragma: no cover - top-level guard
+        print(f"[FAIL] contract compatibility check failed: {err}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/check_contract_compatibility.sh
+++ b/scripts/check_contract_compatibility.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -n "${OPENPORTIO_CONTRACT_COMPAT_BASE_REF:-}" ]]; then
+  BASE_REF="${OPENPORTIO_CONTRACT_COMPAT_BASE_REF}"
+elif [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+  BASE_REF="origin/${GITHUB_BASE_REF}"
+else
+  BASE_REF="origin/develop"
+fi
+
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  if [[ "$BASE_REF" == origin/* ]]; then
+    BRANCH="${BASE_REF#origin/}"
+    git fetch --no-tags --depth=1 origin "$BRANCH"
+  fi
+fi
+
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  echo "[FAIL] base ref not found for compatibility check: $BASE_REF" >&2
+  echo "Set OPENPORTIO_CONTRACT_COMPAT_BASE_REF explicitly if needed." >&2
+  exit 1
+fi
+
+./scripts/generate_contracts_bundle.sh
+
+python3 scripts/check_contract_compatibility.py \
+  --base-ref "$BASE_REF" \
+  --head-bundle docs/generated/contracts-bundle.json \
+  --base-bundle docs/generated/contracts-bundle.json \
+  --exceptions contracts/compat_exceptions.toml
+
+echo "Contract compatibility gate passed against ${BASE_REF}."

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -4,31 +4,35 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-echo "[1/10] cargo fmt --all -- --check"
+echo "[1/11] cargo fmt --all -- --check"
 cargo fmt --all -- --check
 
-echo "[2/10] cargo clippy --workspace --all-targets -- -D warnings"
+echo "[2/11] cargo clippy --workspace --all-targets -- -D warnings"
 cargo clippy --workspace --all-targets -- -D warnings
 
-echo "[3/10] cargo check --workspace"
+echo "[3/11] cargo check --workspace"
 cargo check --workspace
 
-echo "[4/10] cargo test --workspace"
+echo "[4/11] cargo test --workspace"
 cargo test --workspace
 
-echo "[5/10] cargo test -p production-api -- --nocapture"
+echo "[5/11] cargo test -p production-api -- --nocapture"
 cargo test -p production-api -- --nocapture
 
-echo "[6/10] cargo test -p openportio-server --test multiplexing -- --nocapture"
+echo "[6/11] cargo test -p openportio-server --test multiplexing -- --nocapture"
 cargo test -p openportio-server --test multiplexing -- --nocapture
 
-echo "[7/10] scripts/check_contracts_bundle.sh"
+echo "[7/11] scripts/check_contracts_bundle.sh"
 ./scripts/check_contracts_bundle.sh
 
-echo "[8/10] cargo test -p openportio-server openapi_json_is_available -- --nocapture"
+echo "[8/11] scripts/check_contract_compatibility.sh"
+OPENPORTIO_CONTRACT_COMPAT_BASE_REF="${OPENPORTIO_CONTRACT_COMPAT_BASE_REF:-origin/develop}" \
+./scripts/check_contract_compatibility.sh
+
+echo "[9/11] cargo test -p openportio-server openapi_json_is_available -- --nocapture"
 cargo test -p openportio-server openapi_json_is_available -- --nocapture
 
-echo "[9/10] scripts/prod_preflight.sh"
+echo "[10/11] scripts/prod_preflight.sh"
 OPENPORTIO_PREFLIGHT_SECURE=true \
 OPENPORTIO_PREFLIGHT_BOOT_SERVER=true \
 OPENPORTIO_PREFLIGHT_WAIT_SECONDS=120 \
@@ -43,7 +47,7 @@ OPENPORTIO_REQUEST_BODY_LIMIT_BYTES=1048576 \
 OPENPORTIO_MAX_IN_FLIGHT_REQUESTS=1024 \
 ./scripts/prod_preflight.sh
 
-echo "[10/10] scripts/release_dry_run.sh"
+echo "[11/11] scripts/release_dry_run.sh"
 ./scripts/release_dry_run.sh
 
 if cargo audit -V >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add a PR-time REST+gRPC contract compatibility gate that compares current contracts bundle against the base branch
- fail CI on backward-incompatible changes with actionable change IDs and explanations
- add controlled waiver mechanism for intentional breaks via `contracts/compat_exceptions.toml`
- document compatibility policy, non-breaking guidance, and exception process

## What Changed
- new compatibility checker scripts:
  - `scripts/check_contract_compatibility.sh`
  - `scripts/check_contract_compatibility.py`
- new waiver config:
  - `contracts/compat_exceptions.toml`
- CI wiring:
  - `.github/workflows/ci.yml` adds `Contract Compatibility Gate` job
  - PR path fetches base branch ref and compares against `origin/<base_ref>`
- local quality flow update:
  - `scripts/ci_local.sh` now runs compatibility gate
- docs:
  - `docs/contracts-compatibility.md` (policy + waiver process)
  - `docs/ci-workflow.md` (new gate)
  - `docs/release/versioning.md` (compatibility gate expectations)
  - `docs/grpc-contract-docs-strategy.md` (compatibility gate in reproducible flow)
  - `README.md` troubleshooting and local command updates
  - `docs/adr/0001-contract-ssot.md` drift policy updated to reference implemented gate

## Breaking-Change Detection Rules (current)
- REST operation removed (`operation_id`)
- REST operation signature changed (`method`/`path` for same `operation_id`)
- gRPC method removed
- gRPC method bridge shape changed (`http_method`, `path`, `request_schema_ref`, `response_schema_ref`)
- REST<->gRPC mapping link removed

## Controlled Exception Mechanism
- intentional breaks are temporarily waived with `contracts/compat_exceptions.toml` entries
- required fields: `id`, `reason`
- optional: `expires_on`
- expired waivers fail CI; unused waivers are warned

## Acceptance Criteria Mapping (#87)
- PR CI fails on breaking REST/gRPC changes:
  - enforced by new `Contract Compatibility Gate` job
- CI output indicates what changed and why breaking:
  - checker emits `[BREAKING] <id>` plus explicit reason and impact
- Compatibility policy documented:
  - `docs/contracts-compatibility.md`
- Controlled override/exception mechanism documented:
  - `contracts/compat_exceptions.toml` + policy docs

## Validation
- `python3 -m py_compile scripts/check_contract_compatibility.py`
- `./scripts/check_contract_compatibility.sh`
- `./scripts/check_contracts_bundle.sh`

Closes #87
