### PR TITLE
feat(example): harden production-api failure modes and docs (#88)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,6 +1861,7 @@ dependencies = [
  "axum",
  "chrono",
  "home",
+ "jsonwebtoken",
  "openportio-core",
  "openportio-server",
  "serde",

--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@ Use this index for fast incident routing:
 - Startup or deployment regressions:
   - `docs/production/deployment.md`
   - `docs/production/runbook.md`
+  - `docs/production/production-api-runbook.md`
 - Contracts/OpenAPI drift failures:
   - `docs/ci-workflow.md`
   - `scripts/check_contracts_bundle.sh`

--- a/docs/production/production-api-runbook.md
+++ b/docs/production/production-api-runbook.md
@@ -15,6 +15,7 @@ Optional (defaults shown):
 - `PROD_API_DB_MAX_CONNECTIONS=10`
 - `PROD_API_RUN_MIGRATIONS=true`
 - `PROD_API_MIGRATION_RETRY_SECONDS=5`
+- `PROD_API_ENABLE_DRILL_ROUTES=false`
 
 Auth-related (recommended for realistic production flow):
 
@@ -43,6 +44,7 @@ set +a
 
 export PROD_API_DATABASE_URL="postgres://${PROD_API_DB_USER}:${PROD_API_DB_PASSWORD}@127.0.0.1:55432/${PROD_API_DB_NAME}"
 export OPENPORTIO_AUTH_ENABLED='true'
+export PROD_API_ENABLE_DRILL_ROUTES='false'
 
 cargo run -p production-api
 ```
@@ -127,6 +129,55 @@ If readiness does not recover:
 - verify DB container health (`docker ps` / `docker logs`)
 - verify `PROD_API_DATABASE_URL`
 - verify migrations path and logs for migration retry errors
+
+## Failure-Mode Drill Matrix
+
+Use these drills for incident rehearsal and operational readiness validation.
+
+### 1) Auth failure (invalid token)
+
+```bash
+curl -i http://127.0.0.1:4100/v1/notes \
+  -H 'authorization: Bearer invalid-token'
+```
+
+Expected: `401 Unauthorized`.
+
+### 2) Dependency outage
+
+```bash
+docker compose --env-file examples/production-api/.env.local \
+  -f examples/production-api/docker-compose.yml stop postgres
+
+curl -i http://127.0.0.1:4100/readyz
+curl -i http://127.0.0.1:4100/livez
+curl -s -i 'http://127.0.0.1:4100/v1/notes?limit=5' \
+  -H "authorization: Bearer ${TOKEN}"
+```
+
+Expected:
+- `/readyz` -> `503`
+- `/livez` -> `200`
+- `/v1/notes` -> `500`
+
+### 3) Timeout behavior
+
+Enable local drill route and lower timeout budget:
+
+```bash
+export PROD_API_ENABLE_DRILL_ROUTES='true'
+export OPENPORTIO_TIMEOUT_SECONDS='1'
+cargo run -p production-api
+```
+
+Then trigger:
+
+```bash
+curl -i http://127.0.0.1:4100/ops/drill/sleep/2 \
+  -H "authorization: Bearer ${TOKEN}"
+```
+
+Expected: `408 Request Timeout` with body `request timed out`.
 
 ## Shutdown
 

--- a/docs/production/runbook.md
+++ b/docs/production/runbook.md
@@ -57,3 +57,6 @@ OPENPORTIO_CORS_ALLOW_ORIGINS=https://app.example.com \
 Rollback guideline:
 - If preflight has critical failures, stop rollout.
 - Revert to last known-good release and re-run preflight after configuration fixes.
+
+For detailed local failure-mode rehearsal on the production reference service, see:
+- `docs/production/production-api-runbook.md`

--- a/examples/production-api/.env.example
+++ b/examples/production-api/.env.example
@@ -7,3 +7,6 @@ OPENPORTIO_AUTH_ENABLED=true
 OPENPORTIO_AUTH_JWT_SECRET=replace-with-local-only-jwt-secret
 OPENPORTIO_AUTH_ISSUER=https://issuer.local
 OPENPORTIO_AUTH_AUDIENCE=openportio-api
+
+# Local failure-mode drill routes (disabled by default).
+PROD_API_ENABLE_DRILL_ROUTES=false

--- a/examples/production-api/Cargo.toml
+++ b/examples/production-api/Cargo.toml
@@ -23,3 +23,4 @@ home = "=0.5.11"
 
 [dev-dependencies]
 tower.workspace = true
+jsonwebtoken.workspace = true

--- a/examples/production-api/README.md
+++ b/examples/production-api/README.md
@@ -37,6 +37,7 @@ export PROD_API_DATABASE_URL="postgres://${PROD_API_DB_USER}:${PROD_API_DB_PASSW
 export PROD_API_ADDR='127.0.0.1:4100'
 export PROD_API_SERVICE_NAME='production-api'
 export PROD_API_RUN_MIGRATIONS='true'
+export PROD_API_ENABLE_DRILL_ROUTES='false'
 export OPENPORTIO_AUTH_ENABLED='true'
 
 cargo run -p production-api
@@ -146,6 +147,59 @@ docker compose --env-file examples/production-api/.env.local \
 ```bash
 curl -i http://127.0.0.1:4100/readyz
 ```
+
+## Failure-Mode Drills (Recommended)
+
+The example now includes automated coverage for:
+- auth failures (missing/invalid bearer token)
+- dependency outage (database unavailable -> `500` on notes endpoints)
+- timeout behavior (`408` when request exceeds middleware timeout budget)
+- readiness degradation (`/readyz` can fail while `/livez` stays healthy)
+
+### A) Invalid Token Drill
+
+```bash
+curl -i http://127.0.0.1:4100/v1/notes \
+  -H 'authorization: Bearer invalid-token'
+```
+
+Expected: `401 Unauthorized`.
+
+### B) Dependency Outage Drill
+
+```bash
+docker compose --env-file examples/production-api/.env.local \
+  -f examples/production-api/docker-compose.yml stop postgres
+
+curl -i http://127.0.0.1:4100/readyz
+curl -s -i 'http://127.0.0.1:4100/v1/notes?limit=5' \
+  -H "authorization: Bearer ${TOKEN}"
+curl -i http://127.0.0.1:4100/livez
+```
+
+Expected:
+- `/readyz` -> `503`
+- `/v1/notes` -> `500`
+- `/livez` -> `200`
+
+### C) Timeout Drill
+
+Enable drill route and lower timeout budget:
+
+```bash
+export PROD_API_ENABLE_DRILL_ROUTES='true'
+export OPENPORTIO_TIMEOUT_SECONDS='1'
+cargo run -p production-api
+```
+
+Then call:
+
+```bash
+curl -i http://127.0.0.1:4100/ops/drill/sleep/2 \
+  -H "authorization: Bearer ${TOKEN}"
+```
+
+Expected: `408 Request Timeout` with body `request timed out`.
 
 ## Troubleshooting
 

--- a/examples/production-api/src/main.rs
+++ b/examples/production-api/src/main.rs
@@ -26,6 +26,7 @@ struct ProductionConfig {
     max_db_connections: u32,
     run_migrations: bool,
     migration_retry_seconds: u64,
+    enable_drill_routes: bool,
 }
 
 #[derive(Debug)]
@@ -80,6 +81,8 @@ impl ProductionConfig {
         let run_migrations = parse_or_default(&mut lookup, "PROD_API_RUN_MIGRATIONS", true)?;
         let migration_retry_seconds =
             parse_or_default(&mut lookup, "PROD_API_MIGRATION_RETRY_SECONDS", 5)?;
+        let enable_drill_routes =
+            parse_or_default(&mut lookup, "PROD_API_ENABLE_DRILL_ROUTES", false)?;
 
         Ok(Self {
             addr,
@@ -88,6 +91,7 @@ impl ProductionConfig {
             max_db_connections,
             run_migrations,
             migration_retry_seconds,
+            enable_drill_routes,
         })
     }
 }
@@ -200,6 +204,12 @@ struct ListNotesQuery {
 struct NotePath {
     #[validate(range(min = 1))]
     id: i64,
+}
+
+#[openportio_server::dto]
+struct DrillSleepPath {
+    #[validate(range(min = 1, max = 30))]
+    seconds: u64,
 }
 
 #[openportio_server::route(get, "/livez")]
@@ -324,6 +334,14 @@ async fn get_protected_note(
     }))
 }
 
+#[openportio_server::route(get, "/ops/drill/sleep/:seconds", auto_validate, transparent)]
+async fn drill_sleep(ValidatedPath(path): ValidatedPath<DrillSleepPath>) -> Json<StatusResponse> {
+    tokio::time::sleep(Duration::from_secs(path.seconds)).await;
+    Json(StatusResponse {
+        status: "completed",
+    })
+}
+
 impl NoteRow {
     fn into_response(self) -> NoteResponse {
         NoteResponse {
@@ -368,11 +386,20 @@ fn database_error(err: sqlx::Error) -> ApiError {
     )
 }
 
-fn build_rest_router(state: Arc<ProductionApiState>, auth_cfg: AuthRuntimeConfig) -> Router {
-    let notes_router = Router::new()
+fn build_rest_router(
+    state: Arc<ProductionApiState>,
+    auth_cfg: AuthRuntimeConfig,
+    enable_drill_routes: bool,
+) -> Router {
+    let mut protected_router = Router::new()
         .route("/v1/notes", get(list_notes).post(create_note))
-        .route("/protected/notes/:id", get(get_protected_note))
-        .route_layer(from_fn_with_state(auth_cfg, auth::rest_auth_middleware));
+        .route("/protected/notes/:id", get(get_protected_note));
+    if enable_drill_routes {
+        protected_router = protected_router.route("/ops/drill/sleep/:seconds", get(drill_sleep));
+    }
+
+    let notes_router =
+        protected_router.route_layer(from_fn_with_state(auth_cfg, auth::rest_auth_middleware));
 
     Router::new()
         .route("/livez", get(livez))
@@ -429,7 +456,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let rest_state = Arc::new(ProductionApiState::new(config.service_name.clone(), pool));
-    let rest_router = build_rest_router(rest_state, AuthRuntimeConfig::from_env());
+    let rest_router = build_rest_router(
+        rest_state,
+        AuthRuntimeConfig::from_env(),
+        config.enable_drill_routes,
+    );
 
     let grpc_state = Arc::new(AppState::local(config.service_name.clone()));
     OpenportioServer::new()
@@ -452,7 +483,36 @@ async fn main() -> Result<(), Box<dyn Error>> {
 mod tests {
     use super::*;
     use axum::{body::to_bytes, body::Body, http::Request};
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    use openportio_core::auth::{AudienceClaim, JwtClaims};
+    use openportio_server::middleware::MiddlewareConfig;
     use tower::util::ServiceExt;
+
+    fn auth_cfg_for_tests() -> AuthRuntimeConfig {
+        let mut auth_cfg = AuthRuntimeConfig::default();
+        auth_cfg.enabled = true;
+        auth_cfg.jwt_secret = Some("dev-secret".to_string());
+        auth_cfg.expected_issuer = Some("https://issuer.local".to_string());
+        auth_cfg.expected_audience = Some("openportio-api".to_string());
+        auth_cfg
+    }
+
+    fn issue_test_token(secret: &str, subject: &str) -> String {
+        let claims = JwtClaims {
+            sub: subject.to_string(),
+            exp: 4_102_444_800,
+            iss: Some("https://issuer.local".to_string()),
+            aud: Some(AudienceClaim::One("openportio-api".to_string())),
+            scope: Some("read:notes write:notes".to_string()),
+        };
+
+        encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .expect("token should encode")
+    }
 
     #[test]
     fn config_requires_database_url() {
@@ -484,6 +544,7 @@ mod tests {
         assert_eq!(cfg.max_db_connections, 10);
         assert!(cfg.run_migrations);
         assert_eq!(cfg.migration_retry_seconds, 5);
+        assert!(!cfg.enable_drill_routes);
     }
 
     #[tokio::test]
@@ -497,7 +558,7 @@ mod tests {
             "test-production-api".to_string(),
             pool,
         ));
-        let app = build_rest_router(state, AuthRuntimeConfig::default());
+        let app = build_rest_router(state, AuthRuntimeConfig::default(), false);
 
         let response = app
             .oneshot(
@@ -523,12 +584,7 @@ mod tests {
             "test-production-api".to_string(),
             pool,
         ));
-        let mut auth_cfg = AuthRuntimeConfig::default();
-        auth_cfg.enabled = true;
-        auth_cfg.jwt_secret = Some("dev-secret".to_string());
-        auth_cfg.expected_issuer = Some("https://issuer.local".to_string());
-        auth_cfg.expected_audience = Some("openportio-api".to_string());
-        let app = build_rest_router(state, auth_cfg);
+        let app = build_rest_router(state, auth_cfg_for_tests(), false);
 
         let response = app
             .oneshot(
@@ -547,5 +603,146 @@ mod tests {
         let parsed: ApiErrorResponse =
             serde_json::from_slice(&body).expect("error body should parse");
         assert_eq!(parsed.code, "unauthorized");
+    }
+
+    #[tokio::test]
+    async fn notes_route_rejects_invalid_bearer_token() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://127.0.0.1:1/openportio")
+            .expect("lazy pool should build");
+        let state = Arc::new(ProductionApiState::new(
+            "test-production-api".to_string(),
+            pool,
+        ));
+        let app = build_rest_router(state, auth_cfg_for_tests(), false);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/notes")
+                    .header("authorization", "Bearer invalid-token")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let parsed: ApiErrorResponse =
+            serde_json::from_slice(&body).expect("error body should parse");
+        assert_eq!(parsed.code, "unauthorized");
+    }
+
+    #[tokio::test]
+    async fn notes_route_returns_500_when_database_is_unavailable() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://127.0.0.1:1/openportio")
+            .expect("lazy pool should build");
+        let state = Arc::new(ProductionApiState::new(
+            "test-production-api".to_string(),
+            pool,
+        ));
+        let app = build_rest_router(state, auth_cfg_for_tests(), false);
+        let token = issue_test_token("dev-secret", "test-user");
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/notes?limit=5")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let parsed: ApiErrorResponse =
+            serde_json::from_slice(&body).expect("error body should parse");
+        assert_eq!(parsed.code, "internal_error");
+    }
+
+    #[tokio::test]
+    async fn livez_stays_ok_when_readyz_is_degraded() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://127.0.0.1:1/openportio")
+            .expect("lazy pool should build");
+        let state = Arc::new(ProductionApiState::new(
+            "test-production-api".to_string(),
+            pool,
+        ));
+        let app = build_rest_router(state, AuthRuntimeConfig::default(), false);
+
+        let readyz = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/readyz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("readyz request should complete");
+        assert_eq!(readyz.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        let livez = app
+            .oneshot(
+                Request::builder()
+                    .uri("/livez")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("livez request should complete");
+        assert_eq!(livez.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn drill_route_times_out_when_timeout_budget_is_exceeded() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://127.0.0.1:1/openportio")
+            .expect("lazy pool should build");
+        let state = Arc::new(ProductionApiState::new(
+            "test-production-api".to_string(),
+            pool,
+        ));
+        let rest_router = build_rest_router(state, auth_cfg_for_tests(), true);
+        let app = OpenportioServer::new()
+            .without_grpc()
+            .with_rest_router(rest_router)
+            .with_middleware_config(MiddlewareConfig {
+                timeout_seconds: 1,
+                ..MiddlewareConfig::default()
+            })
+            .build_app();
+
+        let token = issue_test_token("dev-secret", "test-user");
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/ops/drill/sleep/2")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let message = String::from_utf8(body.to_vec()).expect("timeout body should be utf8");
+        assert!(message.contains("request timed out"));
     }
 }

--- a/website/docs/.vitepress/config.mts
+++ b/website/docs/.vitepress/config.mts
@@ -25,6 +25,7 @@ export default defineConfig({
       { text: 'REST + gRPC', link: '/guides/rest-grpc' },
       { text: 'DX / DTO', link: '/guides/dx-builder-dto' },
       { text: 'Production', link: '/production/deployment' },
+      { text: 'Failure Drills', link: '/production/failure-modes' },
       { text: 'Contracts', link: '/reference/contracts' }
     ],
     sidebar: [
@@ -44,7 +45,10 @@ export default defineConfig({
       },
       {
         text: 'Production',
-        items: [{ text: 'Deployment Checklist', link: '/production/deployment' }]
+        items: [
+          { text: 'Deployment Checklist', link: '/production/deployment' },
+          { text: 'Failure-Mode Drills', link: '/production/failure-modes' }
+        ]
       },
       {
         text: 'Reference',

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -23,6 +23,8 @@ features:
     details: Route macros, DTO ergonomics, validation extractors, and trait-first escape hatches for complex logic.
   - title: Contract-Driven Delivery
     details: OpenAPI + gRPC contract artifacts with drift checks for safer team integrations.
+  - title: Production Failure Drills
+    details: Auth, dependency outage, timeout, and readiness-degradation drills with reproducible runbooks.
 ---
 
 ## Docs-Only Navigation

--- a/website/docs/production/deployment.md
+++ b/website/docs/production/deployment.md
@@ -47,4 +47,6 @@ npm run docs:build
 ## Deep References
 
 - [`docs/production/deployment.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/production/deployment.md)
+- [`docs/production/production-api-runbook.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/production/production-api-runbook.md)
+- [`production/failure-modes`](/production/failure-modes)
 - [`docs/release/publish-runbook.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/release/publish-runbook.md)

--- a/website/docs/production/failure-modes.md
+++ b/website/docs/production/failure-modes.md
@@ -1,0 +1,83 @@
+# Production Failure-Mode Drills
+
+Use this page to run realistic operational drills on `examples/production-api`.
+
+## Why This Matters
+
+Framework trust is not only about happy-path benchmarks.
+You need reproducible failure handling for:
+
+- auth rejection
+- dependency outage
+- timeout behavior
+- readiness degradation with liveness continuity
+
+## Prerequisites
+
+- start Postgres with `examples/production-api/.env.local`
+- run `cargo run -p production-api`
+- create a test token:
+
+```bash
+TOKEN=$(python3 scripts/generate_dev_jwt.py \
+  --secret "${OPENPORTIO_AUTH_JWT_SECRET}" \
+  --issuer "${OPENPORTIO_AUTH_ISSUER}" \
+  --audience "${OPENPORTIO_AUTH_AUDIENCE}")
+```
+
+## Drill 1: Invalid Token
+
+```bash
+curl -i http://127.0.0.1:4100/v1/notes \
+  -H 'authorization: Bearer invalid-token'
+```
+
+Expected: `401 Unauthorized`.
+
+## Drill 2: Dependency Outage
+
+```bash
+docker compose --env-file examples/production-api/.env.local \
+  -f examples/production-api/docker-compose.yml stop postgres
+
+curl -i http://127.0.0.1:4100/readyz
+curl -i http://127.0.0.1:4100/livez
+curl -s -i 'http://127.0.0.1:4100/v1/notes?limit=5' \
+  -H "authorization: Bearer ${TOKEN}"
+```
+
+Expected:
+- `/readyz` -> `503`
+- `/livez` -> `200`
+- `/v1/notes` -> `500`
+
+Recover DB:
+
+```bash
+docker compose --env-file examples/production-api/.env.local \
+  -f examples/production-api/docker-compose.yml start postgres
+```
+
+## Drill 3: Timeout Budget
+
+Enable local drill routes and force small timeout:
+
+```bash
+export PROD_API_ENABLE_DRILL_ROUTES='true'
+export OPENPORTIO_TIMEOUT_SECONDS='1'
+cargo run -p production-api
+```
+
+Then call:
+
+```bash
+curl -i http://127.0.0.1:4100/ops/drill/sleep/2 \
+  -H "authorization: Bearer ${TOKEN}"
+```
+
+Expected: `408 Request Timeout` and body `request timed out`.
+
+## References
+
+- [examples/production-api/README.md](https://github.com/jaeyoung0509/Openportio/blob/develop/examples/production-api/README.md)
+- [docs/production/production-api-runbook.md](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/production/production-api-runbook.md)


### PR DESCRIPTION
## Summary
- harden `examples/production-api` failure-mode behavior and automated tests
- add timeout drill route (opt-in via env) to make timeout behavior reproducible in ops drills
- significantly improve production docs in both repository markdown and VitePress docs site

## What Changed

### 1) production-api failure-mode hardening
- `examples/production-api/src/main.rs`
  - added config toggle: `PROD_API_ENABLE_DRILL_ROUTES` (default `false`)
  - added auth-protected drill route:
    - `GET /ops/drill/sleep/:seconds`
    - sleeps for requested seconds (validated `1..=30`)
  - updated router wiring so drill route is enabled only when toggle is true

### 2) Expanded automated failure-path tests
- `examples/production-api/src/main.rs` tests now cover:
  - invalid token -> `401`
  - dependency outage on notes endpoint (valid auth, DB down) -> `500`
  - readiness degradation with liveness continuity:
    - `/readyz` -> `503`
    - `/livez` -> `200`
  - timeout behavior under tight middleware budget:
    - drill route exceeds timeout -> `408`

### 3) Secure-by-default env template and docs updates
- `examples/production-api/.env.example`
  - adds `PROD_API_ENABLE_DRILL_ROUTES=false`
- `examples/production-api/README.md`
  - adds failure-mode drill matrix (auth/dependency/timeout/readiness)
- `docs/production/production-api-runbook.md`
  - adds explicit drill commands and expected outcomes
- `docs/production/runbook.md` + root `README.md`
  - links to production-api runbook for incident rehearsal

### 4) Docs site (https://jaeyoung0509.github.io/Openportio/) strengthened
- new page:
  - `website/docs/production/failure-modes.md`
- updated navigation/sidebar:
  - `website/docs/.vitepress/config.mts`
- updated landing + production checklist links:
  - `website/docs/index.md`
  - `website/docs/production/deployment.md`

## Acceptance Criteria Mapping (#88)
- Production example includes automated tests for key failure paths:
  - added explicit tests for auth failure, dependency outage, timeout, readiness degradation
- Readiness/liveness/error responses validated under degraded conditions:
  - dedicated test validates `/readyz` degraded while `/livez` remains healthy
- Documentation clearly explains reproduce/verify failure-mode behavior:
  - README, production runbook, and docs site failure-mode page updated with exact commands + expected statuses
- Security scanners/CI safety baseline preserved:
  - drill route is opt-in (`PROD_API_ENABLE_DRILL_ROUTES=false` by default)
  - local env remains explicit and secret-free templates only

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p production-api -- --nocapture`
- `cargo clippy -p production-api --all-targets -- -D warnings`
- `cargo test --workspace`
- `npm --prefix website run docs:build`

Closes #88
