### PR TITLE
feat(grpc-dx): add FastAPI-like gRPC service registration (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Recommended audience paths:
   - `/protected/whoami`
 - Fluent server builder API:
   - `OpenportioServer::new().with_...().run()`
+  - function-style gRPC registration:
+    - `OpenportioServer::with_grpc_say_hello(async fn(Arc<AppState>, GrpcHelloRequest) -> Result<GrpcHelloResponse, OpenportioError>)`
 - Single-attribute DTO macro (backward-compatible):
   - `#[openportio_server::dto]` for `Deserialize + Validate + ToSchema`
   - keep `utoipa` in your crate dependencies for schema derive expansion
@@ -276,6 +278,38 @@ OpenportioServer::new()
     Ok(())
 }
 ```
+
+### gRPC FastAPI-Like Registration
+
+```rust
+use std::sync::Arc;
+
+use openportio_core::{AppState, OpenportioError};
+use openportio_server::{
+    grpc::{GrpcHelloRequest, GrpcHelloResponse},
+    OpenportioServer,
+};
+
+async fn say_hello(
+    state: Arc<AppState>,
+    request: GrpcHelloRequest,
+) -> Result<GrpcHelloResponse, OpenportioError> {
+    let message = state.greet(&request.name)?;
+    Ok(GrpcHelloResponse { message })
+}
+
+let state = Arc::new(AppState::local("my-app"));
+OpenportioServer::new()
+    .with_state(state)
+    .with_grpc_say_hello(say_hello)
+    .run()
+    .await?;
+```
+
+Migration notes (tonic-trait style -> FastAPI-like style):
+- Before: implement `openportio_rpc::Greeter` trait and manually wire `GreeterServer`.
+- After: provide one async function with typed request/response.
+- Escape hatch remains: `with_grpc_service(...)` and `configure_tonic(...)`.
 
 ### DTO Modes: All-In-One, Composable, Trait-First
 

--- a/crates/openportio-server/src/builder.rs
+++ b/crates/openportio-server/src/builder.rs
@@ -1,11 +1,11 @@
 use std::{
-    convert::Infallible, env, future::IntoFuture, io, marker::PhantomData, net::SocketAddr,
-    sync::Arc,
+    convert::Infallible, env, future::Future, future::IntoFuture, io, marker::PhantomData,
+    net::SocketAddr, sync::Arc,
 };
 
 use axum::Router;
 use http::{Request, Response};
-use openportio_core::AppState;
+use openportio_core::{AppState, OpenportioError};
 use tokio::net::TcpListener;
 use tokio::sync::watch;
 use tonic::{body::BoxBody, server::NamedService, service::Routes};
@@ -146,6 +146,18 @@ impl OpenportioServer {
             None => Routes::new(service).prepare(),
         };
         self.grpc_routes = Some(routes);
+        self
+    }
+
+    pub fn with_grpc_say_hello<H, Fut>(mut self, say_hello: H) -> Self
+    where
+        H: Fn(Arc<AppState>, grpc::GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<grpc::GrpcHelloResponse, OpenportioError>> + Send + 'static,
+    {
+        self.grpc_routes = Some(grpc::build_grpc_routes_from_say_hello_handler(
+            self.state.clone(),
+            say_hello,
+        ));
         self
     }
 

--- a/crates/openportio-server/src/grpc.rs
+++ b/crates/openportio-server/src/grpc.rs
@@ -1,12 +1,18 @@
-use std::sync::Arc;
+use std::{convert::Infallible, future::Future, sync::Arc};
 
 use crate::auth::AuthRuntimeConfig;
-use openportio_core::AppState;
+use http::{Request as HttpRequest, Response as HttpResponse};
+use openportio_core::{AppState, OpenportioError};
 use openportio_rpc::{
     build_hello_response, Greeter, GreeterServer, HelloRequest, HelloResponse, FILE_DESCRIPTOR_SET,
 };
 use tonic::service::Routes;
+use tonic::{body::BoxBody, server::NamedService};
 use tonic::{service::interceptor::InterceptedService, Request, Response, Status};
+use tower::Service;
+
+pub type GrpcHelloRequest = HelloRequest;
+pub type GrpcHelloResponse = HelloResponse;
 
 #[derive(Clone)]
 pub struct GreeterService {
@@ -31,6 +37,38 @@ impl Greeter for GreeterService {
     }
 }
 
+#[derive(Clone)]
+pub struct GreeterFnService<H> {
+    state: Arc<AppState>,
+    say_hello: Arc<H>,
+}
+
+impl<H> GreeterFnService<H> {
+    pub fn new(state: Arc<AppState>, say_hello: H) -> Self {
+        Self {
+            state,
+            say_hello: Arc::new(say_hello),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl<H, Fut> Greeter for GreeterFnService<H>
+where
+    H: Fn(Arc<AppState>, GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<GrpcHelloResponse, OpenportioError>> + Send + 'static,
+{
+    async fn say_hello(
+        &self,
+        request: Request<GrpcHelloRequest>,
+    ) -> Result<Response<GrpcHelloResponse>, Status> {
+        let response = (self.say_hello.as_ref())(self.state.clone(), request.into_inner())
+            .await
+            .map_err(map_error)?;
+        Ok(Response::new(response))
+    }
+}
+
 pub fn build_grpc_service(
     state: Arc<AppState>,
 ) -> InterceptedService<GreeterServer<GreeterService>, GrpcAuthInterceptor> {
@@ -45,12 +83,70 @@ pub fn build_grpc_service_with_auth(
     InterceptedService::new(service, GrpcAuthInterceptor { auth_cfg })
 }
 
+pub fn build_grpc_service_from_say_hello_handler<H, Fut>(
+    state: Arc<AppState>,
+    say_hello: H,
+) -> InterceptedService<GreeterServer<GreeterFnService<H>>, GrpcAuthInterceptor>
+where
+    H: Fn(Arc<AppState>, GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<GrpcHelloResponse, OpenportioError>> + Send + 'static,
+{
+    build_grpc_service_from_say_hello_handler_with_auth(
+        state,
+        AuthRuntimeConfig::from_env(),
+        say_hello,
+    )
+}
+
+pub fn build_grpc_service_from_say_hello_handler_with_auth<H, Fut>(
+    state: Arc<AppState>,
+    auth_cfg: AuthRuntimeConfig,
+    say_hello: H,
+) -> InterceptedService<GreeterServer<GreeterFnService<H>>, GrpcAuthInterceptor>
+where
+    H: Fn(Arc<AppState>, GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<GrpcHelloResponse, OpenportioError>> + Send + 'static,
+{
+    let service = GreeterServer::new(GreeterFnService::new(state, say_hello));
+    InterceptedService::new(service, GrpcAuthInterceptor { auth_cfg })
+}
+
 pub fn build_grpc_routes(state: Arc<AppState>) -> Routes {
     build_grpc_routes_with_auth(state, AuthRuntimeConfig::from_env())
 }
 
 pub fn build_grpc_routes_with_auth(state: Arc<AppState>, auth_cfg: AuthRuntimeConfig) -> Routes {
     build_grpc_routes_with_descriptor_set(state, auth_cfg, FILE_DESCRIPTOR_SET)
+}
+
+pub fn build_grpc_routes_from_say_hello_handler<H, Fut>(
+    state: Arc<AppState>,
+    say_hello: H,
+) -> Routes
+where
+    H: Fn(Arc<AppState>, GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<GrpcHelloResponse, OpenportioError>> + Send + 'static,
+{
+    build_grpc_routes_from_say_hello_handler_with_auth(
+        state,
+        AuthRuntimeConfig::from_env(),
+        say_hello,
+    )
+}
+
+pub fn build_grpc_routes_from_say_hello_handler_with_auth<H, Fut>(
+    state: Arc<AppState>,
+    auth_cfg: AuthRuntimeConfig,
+    say_hello: H,
+) -> Routes
+where
+    H: Fn(Arc<AppState>, GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<GrpcHelloResponse, OpenportioError>> + Send + 'static,
+{
+    build_grpc_routes_with_descriptor_service(
+        build_grpc_service_from_say_hello_handler_with_auth(state, auth_cfg, say_hello),
+        FILE_DESCRIPTOR_SET,
+    )
 }
 
 fn map_error(err: openportio_core::OpenportioError) -> Status {
@@ -62,7 +158,22 @@ fn build_grpc_routes_with_descriptor_set(
     auth_cfg: AuthRuntimeConfig,
     descriptor_set: &'static [u8],
 ) -> Routes {
-    let mut routes = Routes::new(build_grpc_service_with_auth(state, auth_cfg));
+    build_grpc_routes_with_descriptor_service(
+        build_grpc_service_with_auth(state, auth_cfg),
+        descriptor_set,
+    )
+}
+
+fn build_grpc_routes_with_descriptor_service<S>(service: S, descriptor_set: &'static [u8]) -> Routes
+where
+    S: Service<HttpRequest<BoxBody>, Response = HttpResponse<BoxBody>, Error = Infallible>
+        + NamedService
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    let mut routes = Routes::new(service);
 
     match tonic_reflection::server::Builder::configure()
         .register_encoded_file_descriptor_set(descriptor_set)
@@ -127,6 +238,54 @@ impl tonic::service::Interceptor for GrpcAuthInterceptor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn greeter_fn_service_supports_fastapi_like_happy_path() {
+        let service = GreeterFnService::new(
+            Arc::new(AppState::local("grpc-dx-happy")),
+            |_state, request: GrpcHelloRequest| async move {
+                Ok(GrpcHelloResponse {
+                    message: format!("hello from handler, {}", request.name),
+                })
+            },
+        );
+
+        let response = Greeter::say_hello(
+            &service,
+            Request::new(GrpcHelloRequest {
+                name: "Rust".to_string(),
+            }),
+        )
+        .await
+        .expect("handler should succeed");
+
+        assert_eq!(
+            response.into_inner().message,
+            "hello from handler, Rust".to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn greeter_fn_service_maps_domain_failure_to_grpc_status() {
+        let service = GreeterFnService::new(
+            Arc::new(AppState::local("grpc-dx-failure")),
+            |_state, _request: GrpcHelloRequest| async move {
+                Err(OpenportioError::Validation("name is invalid".to_string()))
+            },
+        );
+
+        let status = Greeter::say_hello(
+            &service,
+            Request::new(GrpcHelloRequest {
+                name: "".to_string(),
+            }),
+        )
+        .await
+        .expect_err("handler should fail");
+
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(status.message(), "name is invalid");
+    }
 
     #[test]
     fn invalid_descriptor_set_does_not_panic_grpc_route_build() {

--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -34,12 +34,47 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 - `with_state(...)`: inject shared app state
 - `with_rest_router(...)`: replace default REST router
 - `merge_raw_router(...)`: merge a plain Axum router escape hatch
+- `with_grpc_say_hello(...)`: register gRPC unary handler with function-style DX
 - `with_grpc_service(...)`: add typed gRPC service
 - `configure_tonic(...)` / `configure_tonic_routes(...)`: transform tonic `Routes` before final merge
 - `without_grpc()`: run REST-only mode
 - `with_middleware_config(...)`: configure shared middleware
 - `with_middleware(...)`: add custom router-level middleware
 - `on_startup(...)` / `on_shutdown(...)`: attach lifecycle hooks
+
+## gRPC FastAPI-Like Registration
+
+Openportio now supports function-style gRPC registration for the built-in `Greeter/SayHello`
+endpoint, so you do not need to implement tonic traits for common cases.
+
+```rust
+use std::sync::Arc;
+
+use openportio_core::{AppState, OpenportioError};
+use openportio_server::{
+    grpc::{GrpcHelloRequest, GrpcHelloResponse},
+    OpenportioServer,
+};
+
+async fn say_hello(
+    state: Arc<AppState>,
+    request: GrpcHelloRequest,
+) -> Result<GrpcHelloResponse, OpenportioError> {
+    let message = state.greet(&request.name)?;
+    Ok(GrpcHelloResponse { message })
+}
+
+let state = Arc::new(AppState::local("my-app"));
+let app = OpenportioServer::new()
+    .with_state(state)
+    .with_grpc_say_hello(say_hello)
+    .build_app();
+```
+
+Migration notes (tonic-trait style -> FastAPI-like style):
+- Before: implement `openportio_rpc::Greeter` and wire `GreeterServer` manually.
+- After: provide `async fn(Arc<AppState>, GrpcHelloRequest) -> Result<GrpcHelloResponse, OpenportioError>`.
+- Escape hatch stays available: `with_grpc_service(...)` and `configure_tonic(...)` are unchanged.
 
 ## Raw Escape Hatches
 

--- a/examples/simple-server/README.md
+++ b/examples/simple-server/README.md
@@ -1,6 +1,6 @@
 # simple-server
 
-Runnable sample for FastAPI-like DTO validation, DI, SSE, WebSocket, and single-port REST+gRPC.
+Runnable sample for FastAPI-like DTO validation, DI, SSE, WebSocket, single-port REST+gRPC, and function-style gRPC registration (`with_grpc_say_hello`).
 
 ## Prerequisites
 

--- a/examples/simple-server/src/main.rs
+++ b/examples/simple-server/src/main.rs
@@ -8,10 +8,11 @@ use axum::{
     routing::get,
     Json, Router,
 };
-use openportio_core::AppState;
+use openportio_core::{AppState, OpenportioError};
 use openportio_server::{
     api::{bad_request, ApiError, ValidatedJson, ValidatedPath, ValidatedQuery},
     di::Depends,
+    grpc::{GrpcHelloRequest, GrpcHelloResponse},
     OpenportioServer,
 };
 use serde::{Deserialize, Serialize};
@@ -188,6 +189,14 @@ fn note_event(sequence: u64, kind: &str) -> Event {
     }
 }
 
+async fn grpc_say_hello(
+    state: Arc<AppState>,
+    request: GrpcHelloRequest,
+) -> Result<GrpcHelloResponse, OpenportioError> {
+    let message = state.greet(&request.name)?;
+    Ok(GrpcHelloResponse { message })
+}
+
 const WS_MAX_TEXT_BYTES: usize = 4 * 1024;
 const WS_IDLE_TIMEOUT: Duration = Duration::from_secs(45);
 
@@ -251,6 +260,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     OpenportioServer::new()
         .with_state(state)
+        .with_grpc_say_hello(grpc_say_hello)
         .with_rest_router(custom_router)
         .with_addr(SocketAddr::from(([127, 0, 0, 1], 4000)))
         .on_startup(|addr| {

--- a/website/docs/.vitepress/config.mts
+++ b/website/docs/.vitepress/config.mts
@@ -23,6 +23,7 @@ export default defineConfig({
     nav: [
       { text: 'Getting Started', link: '/getting-started' },
       { text: 'REST + gRPC', link: '/guides/rest-grpc' },
+      { text: 'gRPC DX', link: '/guides/grpc-fastapi-dx' },
       { text: 'DX / DTO', link: '/guides/dx-builder-dto' },
       { text: 'Production', link: '/production/deployment' },
       { text: 'Failure Drills', link: '/production/failure-modes' },
@@ -40,6 +41,7 @@ export default defineConfig({
         text: 'Guides',
         items: [
           { text: 'REST + gRPC Runtime', link: '/guides/rest-grpc' },
+          { text: 'gRPC FastAPI-like DX', link: '/guides/grpc-fastapi-dx' },
           { text: 'Builder / DTO / Validation', link: '/guides/dx-builder-dto' }
         ]
       },

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -49,3 +49,4 @@ Site default: `http://127.0.0.1:5173`
 
 - [`README.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/README.md)
 - [`examples/simple-server/README.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/examples/simple-server/README.md)
+- [`gRPC FastAPI-like DX`](/guides/grpc-fastapi-dx)

--- a/website/docs/guides/grpc-fastapi-dx.md
+++ b/website/docs/guides/grpc-fastapi-dx.md
@@ -1,0 +1,78 @@
+# gRPC FastAPI-like DX
+
+## Function-Style gRPC Registration
+
+Use `with_grpc_say_hello(...)` when you want a FastAPI-like handler flow without tonic trait boilerplate.
+
+```rust
+use std::sync::Arc;
+
+use openportio_core::{AppState, OpenportioError};
+use openportio_server::{
+    grpc::{GrpcHelloRequest, GrpcHelloResponse},
+    OpenportioServer,
+};
+
+async fn say_hello(
+    state: Arc<AppState>,
+    request: GrpcHelloRequest,
+) -> Result<GrpcHelloResponse, OpenportioError> {
+    let message = state.greet(&request.name)?;
+    Ok(GrpcHelloResponse { message })
+}
+
+OpenportioServer::new()
+    .with_state(Arc::new(AppState::local("grpc-dx")))
+    .with_grpc_say_hello(say_hello)
+    .run()
+    .await?;
+```
+
+## Why This Exists
+
+- Keep startup and handler code close to FastAPI-style ergonomics.
+- Preserve typed request/response contracts.
+- Keep auth interceptor and single-port runtime behavior unchanged.
+
+## Escape Hatches (Still Supported)
+
+- `with_grpc_service(...)`: register raw tonic service directly.
+- `configure_tonic(...)`: transform tonic `Routes` before final merge.
+
+Choose these when you need custom tonic internals or advanced service composition.
+
+## Migration: tonic Trait -> Function Handler
+
+Before:
+- implement `openportio_rpc::Greeter` for a service struct
+- wrap with `GreeterServer::new(...)`
+- register through `with_grpc_service(...)`
+
+After:
+- define one async function:
+  - `async fn(Arc<AppState>, GrpcHelloRequest) -> Result<GrpcHelloResponse, OpenportioError>`
+- register with `with_grpc_say_hello(...)`
+
+## Runtime Checks
+
+No-auth smoke check:
+
+```bash
+grpcurl -plaintext 127.0.0.1:3000 list
+grpcurl -plaintext \
+  -import-path crates/openportio-rpc/proto \
+  -proto service.proto \
+  -d '{"name":"Rust"}' \
+  127.0.0.1:3000 \
+  openportio.v1.Greeter/SayHello
+```
+
+Auth behavior is unchanged:
+- missing/invalid token in auth-enabled mode -> `UNAUTHENTICATED`
+- valid token -> normal handler response
+
+## Deep References
+
+- [`docs/fastapi-like-builder.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/fastapi-like-builder.md)
+- [`examples/simple-server/src/main.rs`](https://github.com/jaeyoung0509/Openportio/blob/develop/examples/simple-server/src/main.rs)
+- [`crates/openportio-server/src/grpc.rs`](https://github.com/jaeyoung0509/Openportio/blob/develop/crates/openportio-server/src/grpc.rs)

--- a/website/docs/guides/rest-grpc.md
+++ b/website/docs/guides/rest-grpc.md
@@ -32,6 +32,7 @@ OpenportioServer::new()
 
 ## Deep References
 
+- [`gRPC FastAPI-like DX guide`](/guides/grpc-fastapi-dx)
 - [`README.md` dual-port section](https://github.com/jaeyoung0509/Openportio/blob/develop/README.md)
 - [`docs/production/deployment.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/production/deployment.md)
 - [`crates/openportio-server/tests/multiplexing.rs`](https://github.com/jaeyoung0509/Openportio/blob/develop/crates/openportio-server/tests/multiplexing.rs)


### PR DESCRIPTION
## Summary
- add function-style gRPC registration API via `OpenportioServer::with_grpc_say_hello(...)`
- add `grpc::GreeterFnService` and handler-based route/service builders while keeping tonic trait registration escape hatches intact
- update runnable `examples/simple-server` to use the new gRPC handler style
- expand docs across `README.md`, `docs/fastapi-like-builder.md`, and VitePress guides with migration notes (tonic trait -> function handler)

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `npm --prefix website run docs:build`

Closes #102
