### PR TITLE
feat(grpc-dx): align gRPC validation/DI/error ergonomics (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Recommended audience paths:
   - `OpenportioServer::new().with_...().run()`
   - function-style gRPC registration:
     - `OpenportioServer::with_grpc_say_hello(async fn(Arc<AppState>, GrpcHelloRequest) -> Result<GrpcHelloResponse, OpenportioError>)`
+    - `OpenportioServer::with_grpc_say_hello_with_context(async fn(GrpcHandlerContext, GrpcHelloRequest) -> Result<GrpcHelloResponse, OpenportioError>)`
 - Single-attribute DTO macro (backward-compatible):
   - `#[openportio_server::dto]` for `Deserialize + Validate + ToSchema`
   - keep `utoipa` in your crate dependencies for schema derive expansion
@@ -310,6 +311,57 @@ Migration notes (tonic-trait style -> FastAPI-like style):
 - Before: implement `openportio_rpc::Greeter` trait and manually wire `GreeterServer`.
 - After: provide one async function with typed request/response.
 - Escape hatch remains: `with_grpc_service(...)` and `configure_tonic(...)`.
+
+### gRPC Validation, DI, And Error Pattern
+
+```rust
+use std::sync::Arc;
+
+use openportio_core::{AppState, OpenportioError};
+use openportio_server::{
+    grpc::{
+        validated_grpc_request, GrpcHandlerContext, GrpcHelloRequest, GrpcHelloResponse,
+    },
+    OpenportioServer,
+};
+
+#[derive(openportio_server::serde::Deserialize, openportio_server::OpenPortIOValidate)]
+struct GrpcInput {
+    #[validate(length(min = 1))]
+    name: String,
+}
+
+#[derive(Clone)]
+struct ServiceLabel(String);
+
+impl axum::extract::FromRef<Arc<AppState>> for ServiceLabel {
+    fn from_ref(state: &Arc<AppState>) -> Self {
+        Self(state.config.service_name.clone())
+    }
+}
+
+async fn say_hello(
+    ctx: GrpcHandlerContext,
+    request: GrpcHelloRequest,
+) -> Result<GrpcHelloResponse, OpenportioError> {
+    let input = validated_grpc_request(GrpcInput { name: request.name })?;
+    let label = ctx.depends::<ServiceLabel>();
+    let base = ctx.state().greet(&input.name)?;
+    Ok(GrpcHelloResponse {
+        message: format!("[{}:{}] {}", label.0, ctx.principal().subject, base),
+    })
+}
+
+OpenportioServer::new()
+    .with_grpc_say_hello_with_context(say_hello)
+    .run()
+    .await?;
+```
+
+Expected gRPC status behavior:
+- validation failure -> `INVALID_ARGUMENT`
+- missing/invalid auth token (auth enabled) -> `UNAUTHENTICATED`
+- internal domain failure -> `INTERNAL` with sanitized message (`internal server error`)
 
 ### DTO Modes: All-In-One, Composable, Trait-First
 

--- a/crates/openportio-server/src/builder.rs
+++ b/crates/openportio-server/src/builder.rs
@@ -161,6 +161,18 @@ impl OpenportioServer {
         self
     }
 
+    pub fn with_grpc_say_hello_with_context<H, Fut>(mut self, say_hello: H) -> Self
+    where
+        H: Fn(grpc::GrpcHandlerContext, grpc::GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<grpc::GrpcHelloResponse, OpenportioError>> + Send + 'static,
+    {
+        self.grpc_routes = Some(grpc::build_grpc_routes_from_say_hello_context_handler(
+            self.state.clone(),
+            say_hello,
+        ));
+        self
+    }
+
     pub fn with_grpc_routes(mut self, routes: Routes) -> Self {
         self.grpc_routes = Some(routes.prepare());
         self

--- a/crates/openportio-server/src/grpc.rs
+++ b/crates/openportio-server/src/grpc.rs
@@ -1,8 +1,9 @@
 use std::{convert::Infallible, future::Future, sync::Arc};
 
 use crate::auth::AuthRuntimeConfig;
+use axum::extract::FromRef;
 use http::{Request as HttpRequest, Response as HttpResponse};
-use openportio_core::{AppState, OpenportioError};
+use openportio_core::{auth::AuthPrincipal, AppState, OpenportioError};
 use openportio_rpc::{
     build_hello_response, Greeter, GreeterServer, HelloRequest, HelloResponse, FILE_DESCRIPTOR_SET,
 };
@@ -10,9 +11,55 @@ use tonic::service::Routes;
 use tonic::{body::BoxBody, server::NamedService};
 use tonic::{service::interceptor::InterceptedService, Request, Response, Status};
 use tower::Service;
+use validator::Validate;
 
 pub type GrpcHelloRequest = HelloRequest;
 pub type GrpcHelloResponse = HelloResponse;
+
+#[derive(Clone)]
+pub struct GrpcHandlerContext {
+    state: Arc<AppState>,
+    principal: AuthPrincipal,
+}
+
+impl GrpcHandlerContext {
+    pub fn state(&self) -> Arc<AppState> {
+        self.state.clone()
+    }
+
+    pub fn principal(&self) -> &AuthPrincipal {
+        &self.principal
+    }
+
+    pub fn depends<T>(&self) -> T
+    where
+        T: FromRef<Arc<AppState>>,
+    {
+        T::from_ref(&self.state)
+    }
+}
+
+pub trait GrpcRequestValidation {
+    fn validate_grpc_request(&self) -> Result<(), OpenportioError>;
+}
+
+impl<T> GrpcRequestValidation for T
+where
+    T: Validate,
+{
+    fn validate_grpc_request(&self) -> Result<(), OpenportioError> {
+        self.validate()
+            .map_err(|err| OpenportioError::Validation(format!("request validation failed: {err}")))
+    }
+}
+
+pub fn validated_grpc_request<T>(value: T) -> Result<T, OpenportioError>
+where
+    T: GrpcRequestValidation,
+{
+    value.validate_grpc_request()?;
+    Ok(value)
+}
 
 #[derive(Clone)]
 pub struct GreeterService {
@@ -52,6 +99,21 @@ impl<H> GreeterFnService<H> {
     }
 }
 
+#[derive(Clone)]
+pub struct GreeterContextFnService<H> {
+    state: Arc<AppState>,
+    say_hello: Arc<H>,
+}
+
+impl<H> GreeterContextFnService<H> {
+    pub fn new(state: Arc<AppState>, say_hello: H) -> Self {
+        Self {
+            state,
+            say_hello: Arc::new(say_hello),
+        }
+    }
+}
+
 #[tonic::async_trait]
 impl<H, Fut> Greeter for GreeterFnService<H>
 where
@@ -63,6 +125,33 @@ where
         request: Request<GrpcHelloRequest>,
     ) -> Result<Response<GrpcHelloResponse>, Status> {
         let response = (self.say_hello.as_ref())(self.state.clone(), request.into_inner())
+            .await
+            .map_err(map_error)?;
+        Ok(Response::new(response))
+    }
+}
+
+#[tonic::async_trait]
+impl<H, Fut> Greeter for GreeterContextFnService<H>
+where
+    H: Fn(GrpcHandlerContext, GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<GrpcHelloResponse, OpenportioError>> + Send + 'static,
+{
+    async fn say_hello(
+        &self,
+        request: Request<GrpcHelloRequest>,
+    ) -> Result<Response<GrpcHelloResponse>, Status> {
+        let principal = request
+            .extensions()
+            .get::<AuthPrincipal>()
+            .cloned()
+            .unwrap_or_else(anonymous_principal);
+        let context = GrpcHandlerContext {
+            state: self.state.clone(),
+            principal,
+        };
+
+        let response = (self.say_hello.as_ref())(context, request.into_inner())
             .await
             .map_err(map_error)?;
         Ok(Response::new(response))
@@ -111,6 +200,34 @@ where
     InterceptedService::new(service, GrpcAuthInterceptor { auth_cfg })
 }
 
+pub fn build_grpc_service_from_say_hello_context_handler<H, Fut>(
+    state: Arc<AppState>,
+    say_hello: H,
+) -> InterceptedService<GreeterServer<GreeterContextFnService<H>>, GrpcAuthInterceptor>
+where
+    H: Fn(GrpcHandlerContext, GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<GrpcHelloResponse, OpenportioError>> + Send + 'static,
+{
+    build_grpc_service_from_say_hello_context_handler_with_auth(
+        state,
+        AuthRuntimeConfig::from_env(),
+        say_hello,
+    )
+}
+
+pub fn build_grpc_service_from_say_hello_context_handler_with_auth<H, Fut>(
+    state: Arc<AppState>,
+    auth_cfg: AuthRuntimeConfig,
+    say_hello: H,
+) -> InterceptedService<GreeterServer<GreeterContextFnService<H>>, GrpcAuthInterceptor>
+where
+    H: Fn(GrpcHandlerContext, GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<GrpcHelloResponse, OpenportioError>> + Send + 'static,
+{
+    let service = GreeterServer::new(GreeterContextFnService::new(state, say_hello));
+    InterceptedService::new(service, GrpcAuthInterceptor { auth_cfg })
+}
+
 pub fn build_grpc_routes(state: Arc<AppState>) -> Routes {
     build_grpc_routes_with_auth(state, AuthRuntimeConfig::from_env())
 }
@@ -149,8 +266,47 @@ where
     )
 }
 
+pub fn build_grpc_routes_from_say_hello_context_handler<H, Fut>(
+    state: Arc<AppState>,
+    say_hello: H,
+) -> Routes
+where
+    H: Fn(GrpcHandlerContext, GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<GrpcHelloResponse, OpenportioError>> + Send + 'static,
+{
+    build_grpc_routes_from_say_hello_context_handler_with_auth(
+        state,
+        AuthRuntimeConfig::from_env(),
+        say_hello,
+    )
+}
+
+pub fn build_grpc_routes_from_say_hello_context_handler_with_auth<H, Fut>(
+    state: Arc<AppState>,
+    auth_cfg: AuthRuntimeConfig,
+    say_hello: H,
+) -> Routes
+where
+    H: Fn(GrpcHandlerContext, GrpcHelloRequest) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<GrpcHelloResponse, OpenportioError>> + Send + 'static,
+{
+    build_grpc_routes_with_descriptor_service(
+        build_grpc_service_from_say_hello_context_handler_with_auth(state, auth_cfg, say_hello),
+        FILE_DESCRIPTOR_SET,
+    )
+}
+
 fn map_error(err: openportio_core::OpenportioError) -> Status {
     crate::api::map_domain_error_to_grpc(err)
+}
+
+fn anonymous_principal() -> AuthPrincipal {
+    AuthPrincipal {
+        subject: "anonymous".to_string(),
+        issuer: None,
+        audience: vec![],
+        scopes: vec![],
+    }
 }
 
 fn build_grpc_routes_with_descriptor_set(
@@ -216,6 +372,7 @@ pub struct GrpcAuthInterceptor {
 impl tonic::service::Interceptor for GrpcAuthInterceptor {
     fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
         if !self.auth_cfg.enabled {
+            request.extensions_mut().insert(anonymous_principal());
             return Ok(request);
         }
 
@@ -238,6 +395,24 @@ impl tonic::service::Interceptor for GrpcAuthInterceptor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::extract::FromRef;
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    use tonic::service::Interceptor;
+
+    #[derive(Debug, Clone)]
+    struct ServiceLabel(String);
+
+    impl FromRef<Arc<AppState>> for ServiceLabel {
+        fn from_ref(state: &Arc<AppState>) -> Self {
+            Self(state.config.service_name.clone())
+        }
+    }
+
+    #[derive(Debug, validator::Validate)]
+    struct HelloInput {
+        #[validate(length(min = 1))]
+        name: String,
+    }
 
     #[tokio::test]
     async fn greeter_fn_service_supports_fastapi_like_happy_path() {
@@ -285,6 +460,166 @@ mod tests {
 
         assert_eq!(status.code(), tonic::Code::InvalidArgument);
         assert_eq!(status.message(), "name is invalid");
+    }
+
+    #[tokio::test]
+    async fn greeter_context_service_supports_validation_di_and_principal() {
+        let service = GreeterContextFnService::new(
+            Arc::new(AppState::local("grpc-dx-context")),
+            |ctx: GrpcHandlerContext, request: GrpcHelloRequest| async move {
+                let input = validated_grpc_request(HelloInput { name: request.name })?;
+                let label = ctx.depends::<ServiceLabel>();
+                Ok(GrpcHelloResponse {
+                    message: format!(
+                        "[{}] {} says hello to {}",
+                        label.0,
+                        ctx.principal().subject,
+                        input.name
+                    ),
+                })
+            },
+        );
+
+        let mut request = Request::new(GrpcHelloRequest {
+            name: "Rust".to_string(),
+        });
+        request.extensions_mut().insert(AuthPrincipal {
+            subject: "user-1".to_string(),
+            issuer: Some("https://issuer.local".to_string()),
+            audience: vec!["openportio-api".to_string()],
+            scopes: vec!["read:notes".to_string()],
+        });
+
+        let response = Greeter::say_hello(&service, request)
+            .await
+            .expect("handler should succeed");
+        assert_eq!(
+            response.into_inner().message,
+            "[grpc-dx-context] user-1 says hello to Rust"
+        );
+    }
+
+    #[tokio::test]
+    async fn greeter_context_service_maps_validation_failure_to_grpc_status() {
+        let service = GreeterContextFnService::new(
+            Arc::new(AppState::local("grpc-dx-context-validation")),
+            |_ctx: GrpcHandlerContext, request: GrpcHelloRequest| async move {
+                let _ = validated_grpc_request(HelloInput { name: request.name })?;
+                Ok(GrpcHelloResponse {
+                    message: "ok".to_string(),
+                })
+            },
+        );
+
+        let status = Greeter::say_hello(
+            &service,
+            Request::new(GrpcHelloRequest {
+                name: "".to_string(),
+            }),
+        )
+        .await
+        .expect_err("handler should fail");
+
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert!(status.message().contains("request validation failed"));
+    }
+
+    #[tokio::test]
+    async fn greeter_context_service_sanitizes_internal_failures() {
+        let service = GreeterContextFnService::new(
+            Arc::new(AppState::local("grpc-dx-context-internal")),
+            |_ctx: GrpcHandlerContext, _request: GrpcHelloRequest| async move {
+                Err(OpenportioError::Internal("db exploded".to_string()))
+            },
+        );
+
+        let status = Greeter::say_hello(
+            &service,
+            Request::new(GrpcHelloRequest {
+                name: "Rust".to_string(),
+            }),
+        )
+        .await
+        .expect_err("handler should fail");
+
+        assert_eq!(status.code(), tonic::Code::Internal);
+        assert_eq!(status.message(), "internal server error");
+    }
+
+    #[derive(serde::Serialize)]
+    struct TestClaims {
+        sub: String,
+        exp: usize,
+        iss: String,
+        aud: String,
+    }
+
+    fn issue_test_token(secret: &str) -> String {
+        encode(
+            &Header::new(Algorithm::HS256),
+            &TestClaims {
+                sub: "user-1".to_string(),
+                exp: 4_102_444_800,
+                iss: "https://issuer.local".to_string(),
+                aud: "openportio-api".to_string(),
+            },
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .expect("token should encode")
+    }
+
+    #[test]
+    fn grpc_auth_interceptor_rejects_missing_token_when_auth_enabled() {
+        let mut auth_cfg = AuthRuntimeConfig::default();
+        auth_cfg.enabled = true;
+        auth_cfg.jwt_secret = Some("dev-secret".to_string());
+        auth_cfg.expected_issuer = Some("https://issuer.local".to_string());
+        auth_cfg.expected_audience = Some("openportio-api".to_string());
+        let mut interceptor = GrpcAuthInterceptor { auth_cfg };
+
+        let status = interceptor
+            .call(Request::new(()))
+            .expect_err("missing token should fail");
+        assert_eq!(status.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn grpc_auth_interceptor_injects_principal_for_valid_token() {
+        let mut auth_cfg = AuthRuntimeConfig::default();
+        auth_cfg.enabled = true;
+        auth_cfg.jwt_secret = Some("dev-secret".to_string());
+        auth_cfg.expected_issuer = Some("https://issuer.local".to_string());
+        auth_cfg.expected_audience = Some("openportio-api".to_string());
+        let mut interceptor = GrpcAuthInterceptor { auth_cfg };
+
+        let token = issue_test_token("dev-secret");
+        let mut request = Request::new(());
+        request.metadata_mut().insert(
+            "authorization",
+            format!("Bearer {token}").parse().expect("header value"),
+        );
+
+        let request = interceptor.call(request).expect("valid token should pass");
+        let principal = request
+            .extensions()
+            .get::<AuthPrincipal>()
+            .expect("principal should be injected");
+        assert_eq!(principal.subject, "user-1");
+    }
+
+    #[test]
+    fn grpc_auth_interceptor_injects_anonymous_principal_when_auth_disabled() {
+        let mut interceptor = GrpcAuthInterceptor {
+            auth_cfg: AuthRuntimeConfig::default(),
+        };
+        let request = interceptor
+            .call(Request::new(()))
+            .expect("auth disabled should pass");
+        let principal = request
+            .extensions()
+            .get::<AuthPrincipal>()
+            .expect("principal should be injected");
+        assert_eq!(principal.subject, "anonymous");
     }
 
     #[test]

--- a/crates/openportio-server/src/lib.rs
+++ b/crates/openportio-server/src/lib.rs
@@ -69,6 +69,10 @@ pub mod prelude {
         with_dependency, with_dependency_override, with_dependency_overrides, DependencyOverrides,
         Depends,
     };
+    pub use crate::grpc::{
+        validated_grpc_request, GrpcHandlerContext, GrpcHelloRequest, GrpcHelloResponse,
+        GrpcRequestValidation,
+    };
     pub use crate::AlloyServer;
     pub use crate::MeldServer;
     pub use crate::OpenportioServer;

--- a/docs/fastapi-like-builder.md
+++ b/docs/fastapi-like-builder.md
@@ -35,6 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 - `with_rest_router(...)`: replace default REST router
 - `merge_raw_router(...)`: merge a plain Axum router escape hatch
 - `with_grpc_say_hello(...)`: register gRPC unary handler with function-style DX
+- `with_grpc_say_hello_with_context(...)`: register gRPC unary handler with context-based DI/auth access
 - `with_grpc_service(...)`: add typed gRPC service
 - `configure_tonic(...)` / `configure_tonic_routes(...)`: transform tonic `Routes` before final merge
 - `without_grpc()`: run REST-only mode
@@ -75,6 +76,73 @@ Migration notes (tonic-trait style -> FastAPI-like style):
 - Before: implement `openportio_rpc::Greeter` and wire `GreeterServer` manually.
 - After: provide `async fn(Arc<AppState>, GrpcHelloRequest) -> Result<GrpcHelloResponse, OpenportioError>`.
 - Escape hatch stays available: `with_grpc_service(...)` and `configure_tonic(...)` are unchanged.
+
+gRPC context mode (validation + DI + auth principal):
+
+```rust
+use std::sync::Arc;
+
+use openportio_core::{AppState, OpenportioError};
+use openportio_server::{
+    grpc::{
+        validated_grpc_request, GrpcHandlerContext, GrpcHelloRequest, GrpcHelloResponse,
+    },
+    OpenportioServer,
+};
+
+#[derive(openportio_server::serde::Deserialize, openportio_server::OpenPortIOValidate)]
+struct GrpcInput {
+    #[validate(length(min = 1))]
+    name: String,
+}
+
+#[derive(Clone)]
+struct ServiceLabel(String);
+
+impl axum::extract::FromRef<Arc<AppState>> for ServiceLabel {
+    fn from_ref(state: &Arc<AppState>) -> Self {
+        Self(state.config.service_name.clone())
+    }
+}
+
+async fn say_hello(
+    ctx: GrpcHandlerContext,
+    request: GrpcHelloRequest,
+) -> Result<GrpcHelloResponse, OpenportioError> {
+    let input = validated_grpc_request(GrpcInput { name: request.name })?;
+    let label = ctx.depends::<ServiceLabel>();
+    let base = ctx.state().greet(&input.name)?;
+    Ok(GrpcHelloResponse {
+        message: format!("[{}:{}] {}", label.0, ctx.principal().subject, base),
+    })
+}
+
+let state = Arc::new(AppState::local("my-app"));
+let app = OpenportioServer::new()
+    .with_state(state)
+    .with_grpc_say_hello_with_context(say_hello)
+    .build_app();
+```
+
+## REST vs gRPC DX Alignment
+
+Validation:
+- REST: `ValidatedJson<T>`, `ValidatedQuery<T>`, `ValidatedPath<T>`
+- gRPC: `validated_grpc_request(T)` + `GrpcRequestValidation` trait
+
+Dependency injection:
+- REST: `Depends<T>` extractor (`T: FromRef<State>`)
+- gRPC: `GrpcHandlerContext::depends<T>()` (`T: FromRef<Arc<AppState>>`)
+
+Auth principal:
+- REST: `Extension<AuthPrincipal>`
+- gRPC: `GrpcHandlerContext::principal()`
+
+Error mapping:
+- Both paths map `OpenportioError` through the shared domain mapping contract.
+- Validation failure -> `400` (REST) / `INVALID_ARGUMENT` (gRPC)
+- Missing or invalid bearer token -> `401` (REST) / `UNAUTHENTICATED` (gRPC)
+- Internal domain failure -> sanitized `500` (REST) / sanitized `INTERNAL` (gRPC)
 
 ## Raw Escape Hatches
 

--- a/examples/simple-server/README.md
+++ b/examples/simple-server/README.md
@@ -1,6 +1,6 @@
 # simple-server
 
-Runnable sample for FastAPI-like DTO validation, DI, SSE, WebSocket, single-port REST+gRPC, and function-style gRPC registration (`with_grpc_say_hello`).
+Runnable sample for FastAPI-like DTO validation, DI, SSE, WebSocket, and single-port REST+gRPC with context-based gRPC handlers (`with_grpc_say_hello_with_context`).
 
 ## Prerequisites
 

--- a/examples/simple-server/src/main.rs
+++ b/examples/simple-server/src/main.rs
@@ -12,7 +12,7 @@ use openportio_core::{AppState, OpenportioError};
 use openportio_server::{
     api::{bad_request, ApiError, ValidatedJson, ValidatedPath, ValidatedQuery},
     di::Depends,
-    grpc::{GrpcHelloRequest, GrpcHelloResponse},
+    grpc::{validated_grpc_request, GrpcHandlerContext, GrpcHelloRequest, GrpcHelloResponse},
     OpenportioServer,
 };
 use serde::{Deserialize, Serialize};
@@ -36,6 +36,12 @@ struct NoteQuery {
 struct CreateNoteBody {
     #[validate(length(min = 2, max = 120))]
     title: String,
+}
+
+#[openportio_server::dto]
+struct GrpcSayHelloInput {
+    #[validate(length(min = 1, max = 80))]
+    name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -190,11 +196,19 @@ fn note_event(sequence: u64, kind: &str) -> Event {
 }
 
 async fn grpc_say_hello(
-    state: Arc<AppState>,
+    ctx: GrpcHandlerContext,
     request: GrpcHelloRequest,
 ) -> Result<GrpcHelloResponse, OpenportioError> {
-    let message = state.greet(&request.name)?;
-    Ok(GrpcHelloResponse { message })
+    let input = validated_grpc_request(GrpcSayHelloInput { name: request.name })?;
+    let service = ctx.depends::<ServiceInfo>();
+    let message = ctx.state().greet(&input.name)?;
+    Ok(GrpcHelloResponse {
+        message: format!(
+            "[{}:{}] {message}",
+            service.service_name,
+            ctx.principal().subject
+        ),
+    })
 }
 
 const WS_MAX_TEXT_BYTES: usize = 4 * 1024;
@@ -260,7 +274,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     OpenportioServer::new()
         .with_state(state)
-        .with_grpc_say_hello(grpc_say_hello)
+        .with_grpc_say_hello_with_context(grpc_say_hello)
         .with_rest_router(custom_router)
         .with_addr(SocketAddr::from(([127, 0, 0, 1], 4000)))
         .on_startup(|addr| {

--- a/website/docs/guides/dx-builder-dto.md
+++ b/website/docs/guides/dx-builder-dto.md
@@ -54,6 +54,7 @@ These extractors enforce validation before handler logic runs.
 
 ## Deep References
 
+- [`gRPC FastAPI-like DX`](/guides/grpc-fastapi-dx)
 - [`docs/fastapi-like-builder.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/fastapi-like-builder.md)
 - [`docs/dx-scorecard.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/dx-scorecard.md)
 - [`crates/openportio-server/tests/dto_modes.rs`](https://github.com/jaeyoung0509/Openportio/blob/develop/crates/openportio-server/tests/dto_modes.rs)

--- a/website/docs/guides/grpc-fastapi-dx.md
+++ b/website/docs/guides/grpc-fastapi-dx.md
@@ -28,6 +28,55 @@ OpenportioServer::new()
     .await?;
 ```
 
+## Context Mode: Validation + DI + Auth Principal
+
+Use `with_grpc_say_hello_with_context(...)` when handler code needs typed dependencies and
+authenticated principal access in one place.
+
+```rust
+use std::sync::Arc;
+
+use openportio_core::{AppState, OpenportioError};
+use openportio_server::{
+    grpc::{
+        validated_grpc_request, GrpcHandlerContext, GrpcHelloRequest, GrpcHelloResponse,
+    },
+    OpenportioServer,
+};
+
+#[derive(openportio_server::serde::Deserialize, openportio_server::OpenPortIOValidate)]
+struct GrpcInput {
+    #[validate(length(min = 1))]
+    name: String,
+}
+
+#[derive(Clone)]
+struct ServiceLabel(String);
+
+impl axum::extract::FromRef<Arc<AppState>> for ServiceLabel {
+    fn from_ref(state: &Arc<AppState>) -> Self {
+        Self(state.config.service_name.clone())
+    }
+}
+
+async fn say_hello(
+    ctx: GrpcHandlerContext,
+    request: GrpcHelloRequest,
+) -> Result<GrpcHelloResponse, OpenportioError> {
+    let input = validated_grpc_request(GrpcInput { name: request.name })?;
+    let label = ctx.depends::<ServiceLabel>();
+    let base = ctx.state().greet(&input.name)?;
+    Ok(GrpcHelloResponse {
+        message: format!("[{}:{}] {}", label.0, ctx.principal().subject, base),
+    })
+}
+
+OpenportioServer::new()
+    .with_grpc_say_hello_with_context(say_hello)
+    .run()
+    .await?;
+```
+
 ## Why This Exists
 
 - Keep startup and handler code close to FastAPI-style ergonomics.
@@ -70,6 +119,18 @@ grpcurl -plaintext \
 Auth behavior is unchanged:
 - missing/invalid token in auth-enabled mode -> `UNAUTHENTICATED`
 - valid token -> normal handler response
+
+## REST vs gRPC Mapping Cheatsheet
+
+- Validation failure:
+  - REST: `400` (`validation_error`)
+  - gRPC: `INVALID_ARGUMENT`
+- Auth failure:
+  - REST: `401`
+  - gRPC: `UNAUTHENTICATED`
+- Internal domain error:
+  - REST: `500` + sanitized message
+  - gRPC: `INTERNAL` + sanitized message
 
 ## Deep References
 


### PR DESCRIPTION
## Summary
- add gRPC context DX primitives: `GrpcHandlerContext`, `GrpcRequestValidation`, and `validated_grpc_request(...)`
- add context-based gRPC registration API: `OpenportioServer::with_grpc_say_hello_with_context(...)`
- keep existing tonic and function-style escape hatches (`with_grpc_service`, `with_grpc_say_hello`, `configure_tonic`) intact
- align auth behavior by always injecting a principal into gRPC request extensions (anonymous when auth is disabled)
- expand docs with REST vs gRPC side-by-side validation/DI/error mapping guidance and troubleshooting codes

## Validation
- `cargo fmt --all`
- `cargo clippy -p openportio-server -p simple-server --all-targets -- -D warnings`
- `cargo test -p openportio-server --tests`
- `cargo test -p simple-server`
- `cargo test --workspace`
- `npm --prefix website run docs:build`

Closes #103
