### PR TITLE
docs(site): improve REST documentation discoverability and depth (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Openportio is a Rust server framework focused on **FastAPI-like developer ergono
 
 > Migration note: the project was renamed from `Meld` to `Openportio`. Runtime keeps `MELD_*` env aliases for backward compatibility, but new setups should use `OPENPORTIO_*`.
 
+Official docs:
+- [Openportio Docs](https://jaeyoung0509.github.io/Openportio/)
+- [REST FastAPI-like DX](https://jaeyoung0509.github.io/Openportio/guides/rest-fastapi-dx)
+- [gRPC FastAPI-like DX](https://jaeyoung0509.github.io/Openportio/guides/grpc-fastapi-dx)
+
 ## Start Here
 
 If you are evaluating Openportio for production, use this order:
@@ -246,7 +251,7 @@ npm run docs:build
 ```
 
 After merge to `develop` or `main`, GitHub Actions deploys the docs site to:
-- `https://jaeyoung0509.github.io/Openportio/`
+- [https://jaeyoung0509.github.io/Openportio/](https://jaeyoung0509.github.io/Openportio/)
 
 ## Repository Layout
 

--- a/website/docs/.vitepress/config.mts
+++ b/website/docs/.vitepress/config.mts
@@ -23,6 +23,7 @@ export default defineConfig({
     nav: [
       { text: 'Getting Started', link: '/getting-started' },
       { text: 'REST + gRPC', link: '/guides/rest-grpc' },
+      { text: 'REST DX', link: '/guides/rest-fastapi-dx' },
       { text: 'gRPC DX', link: '/guides/grpc-fastapi-dx' },
       { text: 'DX / DTO', link: '/guides/dx-builder-dto' },
       { text: 'Production', link: '/production/deployment' },
@@ -41,6 +42,7 @@ export default defineConfig({
         text: 'Guides',
         items: [
           { text: 'REST + gRPC Runtime', link: '/guides/rest-grpc' },
+          { text: 'REST FastAPI-like DX', link: '/guides/rest-fastapi-dx' },
           { text: 'gRPC FastAPI-like DX', link: '/guides/grpc-fastapi-dx' },
           { text: 'Builder / DTO / Validation', link: '/guides/dx-builder-dto' }
         ]

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -49,4 +49,5 @@ Site default: `http://127.0.0.1:5173`
 
 - [`README.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/README.md)
 - [`examples/simple-server/README.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/examples/simple-server/README.md)
+- [`REST FastAPI-like DX`](/guides/rest-fastapi-dx)
 - [`gRPC FastAPI-like DX`](/guides/grpc-fastapi-dx)

--- a/website/docs/guides/dx-builder-dto.md
+++ b/website/docs/guides/dx-builder-dto.md
@@ -54,6 +54,7 @@ These extractors enforce validation before handler logic runs.
 
 ## Deep References
 
+- [`REST FastAPI-like DX`](/guides/rest-fastapi-dx)
 - [`gRPC FastAPI-like DX`](/guides/grpc-fastapi-dx)
 - [`docs/fastapi-like-builder.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/fastapi-like-builder.md)
 - [`docs/dx-scorecard.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/dx-scorecard.md)

--- a/website/docs/guides/rest-fastapi-dx.md
+++ b/website/docs/guides/rest-fastapi-dx.md
@@ -1,0 +1,129 @@
+# REST FastAPI-like DX
+
+## Goal
+
+This guide focuses on the REST developer experience in Openportio:
+- minimal handler boilerplate
+- structured validation
+- typed dependency injection
+- predictable auth and error behavior
+
+## Quick REST Runtime
+
+```rust
+use openportio_server::OpenportioServer;
+
+OpenportioServer::new()
+    .with_addr(([127, 0, 0, 1], 3000).into())
+    .run()
+    .await?;
+```
+
+Core REST endpoints from default router:
+- `GET /health`
+- `GET /hello/:name`
+- `GET /protected/whoami`
+- `GET /events` (SSE)
+- `GET /ws` (WebSocket upgrade)
+
+## Handler Pattern
+
+```rust
+use axum::Json;
+use openportio_server::api::{ApiError, ValidatedJson};
+
+#[openportio_server::dto]
+struct CreateNoteBody {
+    #[validate(length(min = 2, max = 120))]
+    title: String,
+}
+
+#[openportio_server::route(post, "/notes", auto_validate, transparent)]
+async fn create_note(
+    ValidatedJson(body): ValidatedJson<CreateNoteBody>,
+) -> Result<Json<String>, ApiError> {
+    Ok(Json(body.title))
+}
+```
+
+Recommended mode:
+- use `auto_validate, transparent`
+- keep extractor types explicit in handler signature
+- avoid hidden macro rewrites
+
+## DTO Modes
+
+1. All-in-one macro:
+- `#[openportio_server::dto]`
+
+2. Composable derive mode:
+- `Deserialize + OpenPortIOValidate + OpenPortIOSchema`
+
+3. Trait-first mode:
+- implement `RequestValidation` directly for custom rules
+
+## Dependency Injection
+
+REST DI uses `Depends<T>` with request-scoped caching.
+
+```rust
+use axum::{extract::FromRef, Json};
+use openportio_server::di::Depends;
+
+#[derive(Clone)]
+struct ServiceLabel(String);
+
+impl FromRef<std::sync::Arc<openportio_core::AppState>> for ServiceLabel {
+    fn from_ref(state: &std::sync::Arc<openportio_core::AppState>) -> Self {
+        Self(state.config.service_name.clone())
+    }
+}
+
+async fn read_label(Depends(label): Depends<ServiceLabel>) -> Json<String> {
+    Json(label.0)
+}
+```
+
+## Auth Behavior
+
+`/protected/whoami` is the REST auth probe endpoint.
+
+- auth disabled (`OPENPORTIO_AUTH_ENABLED=false`):
+  - returns `200` with anonymous principal
+- auth enabled:
+  - missing/invalid bearer token returns `401`
+  - valid token returns current principal
+
+## Error Model
+
+REST validation and domain failures map into a stable JSON shape:
+
+```json
+{
+  "code": "validation_error",
+  "message": "request validation failed",
+  "detail": [
+    { "loc": ["body", "title"], "msg": "length", "type": "length" }
+  ]
+}
+```
+
+Status mapping summary:
+- validation failure: `400`
+- auth failure: `401`
+- internal domain failure: `500` (sanitized message)
+
+## Smoke Checks
+
+```bash
+curl -s http://127.0.0.1:3000/health
+curl -s http://127.0.0.1:3000/hello/Rust
+curl -s http://127.0.0.1:3000/protected/whoami
+curl -s http://127.0.0.1:3000/openapi.json
+```
+
+## Deep References
+
+- [`docs/fastapi-like-builder.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/fastapi-like-builder.md)
+- [`examples/simple-server/src/main.rs`](https://github.com/jaeyoung0509/Openportio/blob/develop/examples/simple-server/src/main.rs)
+- [`crates/openportio-server/src/api.rs`](https://github.com/jaeyoung0509/Openportio/blob/develop/crates/openportio-server/src/api.rs)

--- a/website/docs/guides/rest-grpc.md
+++ b/website/docs/guides/rest-grpc.md
@@ -32,6 +32,7 @@ OpenportioServer::new()
 
 ## Deep References
 
+- [`REST FastAPI-like DX guide`](/guides/rest-fastapi-dx)
 - [`gRPC FastAPI-like DX guide`](/guides/grpc-fastapi-dx)
 - [`README.md` dual-port section](https://github.com/jaeyoung0509/Openportio/blob/develop/README.md)
 - [`docs/production/deployment.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/production/deployment.md)

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -32,6 +32,11 @@ features:
 This portal is intentionally focused on documentation only.
 Use the top navigation to jump straight to setup, runtime guides, DX patterns, and contract references.
 
+Recommended quick path:
+- Runtime topology: `/guides/rest-grpc`
+- REST authoring DX: `/guides/rest-fastapi-dx`
+- gRPC authoring DX: `/guides/grpc-fastapi-dx`
+
 ## Source Mapping
 
 Openportio keeps deep technical markdown in the repository and surfaces curated entry points here.


### PR DESCRIPTION
## Summary
- add a dedicated REST guide page: `website/docs/guides/rest-fastapi-dx.md`
- expose REST docs more clearly from top nav and sidebar
- cross-link REST guide from getting-started, runtime, and DTO/DX pages
- add a quick recommended path in docs home so users can jump directly to REST or gRPC authoring docs

## Validation
- `npm --prefix website run docs:check-links`
- `npm --prefix website run docs:build`

Closes #104
