### PR TITLE
feat(example): integrated REST+gRPC onboarding flow (#109)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2596,6 +2596,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "futures-util",
+ "jsonwebtoken",
  "openportio-core",
  "openportio-server",
  "serde",

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ If you are evaluating Openportio for production, use this order:
 5. Architecture decisions for contributors:
    - `docs/adr/README.md`
    - `docs/adr/0001-contract-ssot.md`
+6. Integrated onboarding example (REST+gRPC+DI+validation+auth toggle):
+   - `examples/simple-server/README.md`
 
 Recommended audience paths:
-- App developers: Quick Start -> Builder/DTO section -> `examples/simple-server`
+- App developers: Quick Start -> Builder/DTO section -> integrated onboarding example `examples/simple-server/README.md`
 - Platform/ops: Production docs -> preflight script -> release runbook
 - Framework contributors: CI/testing sections -> contract generation -> ADRs -> open issues
 
@@ -261,8 +263,8 @@ crates/openportio-rpc      # proto, tonic codegen, grpc-docgen tool
 crates/openportio-server   # REST + gRPC routing, middleware, builder API
 website/            # VitePress documentation portal (docs-only UX)
 contracts/           # explicit REST <-> gRPC mapping definitions
-examples/production-api
-examples/simple-server
+examples/production-api   # production-grade reference
+examples/simple-server    # integrated onboarding reference (REST+gRPC+DI+validation+auth toggle)
 examples/openportio-app
 docs/
 scripts/

--- a/examples/simple-server/Cargo.toml
+++ b/examples/simple-server/Cargo.toml
@@ -18,5 +18,6 @@ utoipa.workspace = true
 
 [dev-dependencies]
 futures-util.workspace = true
+jsonwebtoken.workspace = true
 tokio-tungstenite.workspace = true
 tower.workspace = true

--- a/examples/simple-server/README.md
+++ b/examples/simple-server/README.md
@@ -1,6 +1,13 @@
 # simple-server
 
-Runnable sample for FastAPI-like DTO validation, DI, SSE, WebSocket, and single-port REST+gRPC with context-based gRPC handlers (`with_grpc_say_hello_with_context`).
+Integrated onboarding reference for Openportio.
+
+This example demonstrates, in one runnable app:
+- REST DTO validation (`ValidatedJson`, `ValidatedQuery`, `ValidatedPath`)
+- Depends-style DI in REST (`Depends<T>`)
+- gRPC context-based handler with validation + DI + principal
+- shared application use case reused by REST and gRPC handlers
+- single-port REST + gRPC runtime with optional auth toggle
 
 ## Prerequisites
 
@@ -22,6 +29,7 @@ cargo run -p simple-server
 ```bash
 curl -s http://127.0.0.1:4000/health
 curl -s http://127.0.0.1:4000/notes?limit=3
+curl -i 'http://127.0.0.1:4000/notes?limit=0'   # expected 400 validation_error
 ```
 
 ## gRPC Quickstart (No Auth)
@@ -34,9 +42,16 @@ grpcurl -plaintext \
   -d '{"name":"Rust"}' \
   127.0.0.1:4000 \
   openportio.v1.Greeter/SayHello
+
+grpcurl -plaintext \
+  -import-path crates/openportio-rpc/proto \
+  -proto service.proto \
+  -d '{"name":""}' \
+  127.0.0.1:4000 \
+  openportio.v1.Greeter/SayHello   # expected INVALID_ARGUMENT
 ```
 
-## gRPC Auth Flow
+## Optional Auth Toggle (REST + gRPC)
 
 Restart server with auth enabled:
 
@@ -53,7 +68,13 @@ Alternative auth mode:
   `OPENPORTIO_AUTH_JWKS_URL=<issuer jwks endpoint>`
 - optional: `OPENPORTIO_AUTH_JWKS_REFRESH_SECS`, `OPENPORTIO_AUTH_JWKS_ALGORITHMS`
 
-Call without token (expected `UNAUTHENTICATED`):
+Call protected REST without token (expected `401`):
+
+```bash
+curl -i http://127.0.0.1:4000/protected/greet/Rust
+```
+
+Call gRPC without token (expected `UNAUTHENTICATED`):
 
 ```bash
 grpcurl -plaintext \
@@ -73,7 +94,20 @@ TOKEN=$(python3 scripts/generate_dev_jwt.py \
   --audience openportio-api)
 ```
 
-Call with token (expected success):
+## Shared Use Case Across REST + gRPC
+
+Both endpoints execute the same greeting use case:
+- REST: `GET /protected/greet/:id`
+- gRPC: `openportio.v1.Greeter/SayHello`
+
+Call REST with token (expected `200`):
+
+```bash
+curl -s http://127.0.0.1:4000/protected/greet/Rust \
+  -H "authorization: Bearer ${TOKEN}"
+```
+
+Call gRPC with token (expected success):
 
 ```bash
 grpcurl -plaintext \
@@ -83,6 +117,19 @@ grpcurl -plaintext \
   -d '{"name":"Rust"}' \
   127.0.0.1:4000 \
   openportio.v1.Greeter/SayHello
+```
+
+Expected message prefix contains service/adapter/actor metadata from DI + principal context:
+- REST: `[simple-server:rest:<subject>] ...`
+- gRPC: `[simple-server:grpc:<subject>] ...`
+
+## DI Example Check
+
+REST `GET /notes/:id` uses `Depends<ServiceInfo>` and request context extraction:
+
+```bash
+curl -s http://127.0.0.1:4000/notes/Rust \
+  -H "x-request-id: onboarding-1"
 ```
 
 ## Troubleshooting

--- a/examples/simple-server/src/main.rs
+++ b/examples/simple-server/src/main.rs
@@ -2,15 +2,17 @@ use std::{convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::{
     extract::ws::{Message, WebSocket, WebSocketUpgrade},
-    extract::{FromRef, FromRequestParts, State},
+    extract::{Extension, FromRef, FromRequestParts, State},
     http::request::Parts,
+    middleware::from_fn_with_state,
     response::sse::{Event, KeepAlive, Sse},
     routing::get,
     Json, Router,
 };
-use openportio_core::{AppState, OpenportioError};
+use openportio_core::{auth::AuthPrincipal, AppState, OpenportioError};
 use openportio_server::{
     api::{bad_request, ApiError, ValidatedJson, ValidatedPath, ValidatedQuery},
+    auth::{self, AuthRuntimeConfig},
     di::Depends,
     grpc::{validated_grpc_request, GrpcHandlerContext, GrpcHelloRequest, GrpcHelloResponse},
     OpenportioServer,
@@ -59,6 +61,13 @@ struct NotesListResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+struct ProtectedGreetingResponse {
+    subject: String,
+    message: String,
+    service_name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 struct NoteEventPayload {
     sequence: u64,
     kind: String,
@@ -100,6 +109,17 @@ where
     }
 }
 
+fn execute_shared_greeting_use_case(
+    state: &Arc<AppState>,
+    service_name: &str,
+    actor: &str,
+    name: &str,
+    protocol: &'static str,
+) -> Result<String, OpenportioError> {
+    let greeting = state.greet(name)?;
+    Ok(format!("[{service_name}:{protocol}:{actor}] {greeting}"))
+}
+
 #[openportio_server::route(get, "/notes/:id", auto_validate, transparent)]
 async fn get_note(
     ctx: RequestContext,
@@ -114,6 +134,29 @@ async fn get_note(
         id: path.id,
         title,
         request_id: ctx.request_id,
+        service_name: service.service_name,
+    }))
+}
+
+#[openportio_server::route(get, "/protected/greet/:id", auto_validate, transparent)]
+async fn get_protected_greet(
+    Extension(principal): Extension<AuthPrincipal>,
+    Depends(service): Depends<ServiceInfo>,
+    State(state): State<Arc<AppState>>,
+    ValidatedPath(path): ValidatedPath<NotePath>,
+) -> Result<Json<ProtectedGreetingResponse>, ApiError> {
+    let message = execute_shared_greeting_use_case(
+        &state,
+        &service.service_name,
+        &principal.subject,
+        &path.id,
+        "rest",
+    )
+    .map_err(|err| bad_request(err.to_string()))?;
+
+    Ok(Json(ProtectedGreetingResponse {
+        subject: principal.subject,
+        message,
         service_name: service.service_name,
     }))
 }
@@ -201,14 +244,14 @@ async fn grpc_say_hello(
 ) -> Result<GrpcHelloResponse, OpenportioError> {
     let input = validated_grpc_request(GrpcSayHelloInput { name: request.name })?;
     let service = ctx.depends::<ServiceInfo>();
-    let message = ctx.state().greet(&input.name)?;
-    Ok(GrpcHelloResponse {
-        message: format!(
-            "[{}:{}] {message}",
-            service.service_name,
-            ctx.principal().subject
-        ),
-    })
+    let message = execute_shared_greeting_use_case(
+        &ctx.state(),
+        &service.service_name,
+        &ctx.principal().subject,
+        &input.name,
+        "grpc",
+    )?;
+    Ok(GrpcHelloResponse { message })
 }
 
 const WS_MAX_TEXT_BYTES: usize = 4 * 1024;
@@ -261,15 +304,23 @@ async fn handle_ws_echo_session(mut socket: WebSocket) {
     }
 }
 
+fn build_protected_router(auth_cfg: AuthRuntimeConfig) -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/protected/greet/:id", get(get_protected_greet))
+        .route_layer(from_fn_with_state(auth_cfg, auth::rest_auth_middleware))
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let state = Arc::new(AppState::local("simple-server"));
+    let auth_cfg = AuthRuntimeConfig::from_env();
     let custom_router = Router::new()
         .route("/notes", get(list_notes).post(create_note))
         .route("/notes/raw", axum::routing::post(create_note_raw))
         .route("/events", get(stream_note_events))
         .route("/ws", get(ws_echo))
         .route("/notes/:id", get(get_note))
+        .merge(build_protected_router(auth_cfg))
         .with_state(state.clone());
 
     OpenportioServer::new()
@@ -290,6 +341,8 @@ mod tests {
     use super::*;
     use axum::{body::to_bytes, http::Request};
     use futures_util::{SinkExt, StreamExt as FuturesStreamExt};
+    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+    use openportio_core::auth::{AudienceClaim, JwtClaims};
     use tokio::net::TcpListener;
     use tokio::sync::oneshot;
     use tokio::time::{timeout, Duration};
@@ -304,7 +357,43 @@ mod tests {
             .route("/events", get(stream_note_events))
             .route("/ws", get(ws_echo))
             .route("/notes/:id", get(get_note))
+            .merge(build_protected_router(AuthRuntimeConfig::default()))
             .with_state(state)
+    }
+
+    fn app_with_auth_enabled() -> Router {
+        let state = Arc::new(AppState::local("simple-server-test"));
+        let mut auth_cfg = AuthRuntimeConfig::default();
+        auth_cfg.enabled = true;
+        auth_cfg.jwt_secret = Some("dev-secret".to_string());
+        auth_cfg.expected_issuer = Some("https://issuer.local".to_string());
+        auth_cfg.expected_audience = Some("openportio-api".to_string());
+
+        Router::new()
+            .route("/notes", get(list_notes).post(create_note))
+            .route("/notes/raw", axum::routing::post(create_note_raw))
+            .route("/events", get(stream_note_events))
+            .route("/ws", get(ws_echo))
+            .route("/notes/:id", get(get_note))
+            .merge(build_protected_router(auth_cfg))
+            .with_state(state)
+    }
+
+    fn issue_test_token(secret: &str, subject: &str) -> String {
+        let claims = JwtClaims {
+            sub: subject.to_string(),
+            exp: 4_102_444_800,
+            iss: Some("https://issuer.local".to_string()),
+            aud: Some(AudienceClaim::One("openportio-api".to_string())),
+            scope: Some("read:notes write:notes".to_string()),
+        };
+
+        encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .expect("token should encode")
     }
 
     #[tokio::test]
@@ -409,6 +498,72 @@ mod tests {
         assert!(detail
             .iter()
             .any(|issue| issue.loc.first() == Some(&"path".to_string())));
+    }
+
+    #[tokio::test]
+    async fn protected_route_requires_auth_when_enabled() {
+        let response = app_with_auth_enabled()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/protected/greet/rust")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn protected_route_succeeds_with_valid_token() {
+        let token = issue_test_token("dev-secret", "user-1");
+
+        let response = app_with_auth_enabled()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/protected/greet/rust")
+                    .header("authorization", format!("Bearer {token}"))
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .expect("request should complete");
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let parsed: ProtectedGreetingResponse =
+            serde_json::from_slice(&body).expect("protected route payload");
+        assert_eq!(parsed.subject, "user-1");
+        assert!(parsed.message.contains("[simple-server-test:rest:user-1]"));
+    }
+
+    #[test]
+    fn shared_greeting_use_case_is_protocol_agnostic() {
+        let state = Arc::new(AppState::local("simple-server-test"));
+        let rest_message = execute_shared_greeting_use_case(
+            &state,
+            "simple-server-test",
+            "rest-user",
+            "Rust",
+            "rest",
+        )
+        .expect("rest message");
+        let grpc_message = execute_shared_greeting_use_case(
+            &state,
+            "simple-server-test",
+            "grpc-user",
+            "Rust",
+            "grpc",
+        )
+        .expect("grpc message");
+
+        assert!(rest_message.contains("[simple-server-test:rest:rest-user]"));
+        assert!(grpc_message.contains("[simple-server-test:grpc:grpc-user]"));
     }
 
     #[tokio::test]

--- a/website/docs/guides/grpc-fastapi-dx.md
+++ b/website/docs/guides/grpc-fastapi-dx.md
@@ -135,5 +135,6 @@ Auth behavior is unchanged:
 ## Deep References
 
 - [`docs/fastapi-like-builder.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/fastapi-like-builder.md)
+- [`examples/simple-server/README.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/examples/simple-server/README.md)
 - [`examples/simple-server/src/main.rs`](https://github.com/jaeyoung0509/Openportio/blob/develop/examples/simple-server/src/main.rs)
 - [`crates/openportio-server/src/grpc.rs`](https://github.com/jaeyoung0509/Openportio/blob/develop/crates/openportio-server/src/grpc.rs)

--- a/website/docs/guides/rest-fastapi-dx.md
+++ b/website/docs/guides/rest-fastapi-dx.md
@@ -125,5 +125,6 @@ curl -s http://127.0.0.1:3000/openapi.json
 ## Deep References
 
 - [`docs/fastapi-like-builder.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/fastapi-like-builder.md)
+- [`examples/simple-server/README.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/examples/simple-server/README.md)
 - [`examples/simple-server/src/main.rs`](https://github.com/jaeyoung0509/Openportio/blob/develop/examples/simple-server/src/main.rs)
 - [`crates/openportio-server/src/api.rs`](https://github.com/jaeyoung0509/Openportio/blob/develop/crates/openportio-server/src/api.rs)

--- a/website/docs/guides/rest-grpc.md
+++ b/website/docs/guides/rest-grpc.md
@@ -34,6 +34,7 @@ OpenportioServer::new()
 
 - [`REST FastAPI-like DX guide`](/guides/rest-fastapi-dx)
 - [`gRPC FastAPI-like DX guide`](/guides/grpc-fastapi-dx)
+- [`examples/simple-server/README.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/examples/simple-server/README.md)
 - [`README.md` dual-port section](https://github.com/jaeyoung0509/Openportio/blob/develop/README.md)
 - [`docs/production/deployment.md`](https://github.com/jaeyoung0509/Openportio/blob/develop/docs/production/deployment.md)
 - [`crates/openportio-server/tests/multiplexing.rs`](https://github.com/jaeyoung0509/Openportio/blob/develop/crates/openportio-server/tests/multiplexing.rs)


### PR DESCRIPTION
## Summary
- upgrade `examples/simple-server` into an integrated onboarding reference with REST+gRPC in one app
- add a REST auth-protected endpoint and keep gRPC auth flow to show success/failure paths
- reuse one shared greeting use case from both REST and gRPC handlers (ports/adapters style)
- refresh docs links so guides and root README point to the onboarding example README

## What Changed
- `examples/simple-server/src/main.rs`
  - add `build_protected_router(...)` with `rest_auth_middleware`
  - add `GET /protected/greet/:id` (auth-required when auth is enabled)
  - add `execute_shared_greeting_use_case(...)` and reuse it from both REST + gRPC handlers
  - add tests for:
    - protected REST auth failure (`401`)
    - protected REST auth success (`200`)
    - shared use case behavior across protocols
- `examples/simple-server/README.md`
  - document one-command run, REST/gRPC smoke checks, validation failure, auth toggle, and shared-use-case calls
- `README.md`
  - point app-developer quick path to integrated onboarding example
- docs guides
  - update deep-reference links to include `examples/simple-server/README.md`

## Validation
- `cargo fmt --all`
- `cargo clippy -p simple-server --all-targets -- -D warnings`
- `cargo test -p simple-server`
- `npm --prefix website run docs:check-links`
- `npm --prefix website run docs:build`

Closes #109
